### PR TITLE
Enable group quest basics

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -699,3 +699,127 @@ async def get_directions(payload: dict = Body(...)):
         "totalTime": "22 mins",
     }
 
+
+@app.post("/create-group-quest")
+async def create_group_quest(payload: dict = Body(...)):
+    """Create a shared group quest and set user active state."""
+    user_id = payload.get("userId")
+    quest_id = payload.get("questId")
+    if not user_id or not quest_id:
+        return {"error": "userId and questId required"}
+
+    group_id = hashlib.sha1(f"{user_id}-{quest_id}-{datetime.utcnow()}".encode()).hexdigest()[:8]
+    project_id = creds.project_id
+
+    group_doc = {
+        "questId": quest_id,
+        "members": [user_id],
+        "progress": {user_id: []},
+        "createdAt": datetime.utcnow().isoformat(),
+    }
+    group_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/groups/{group_id}"
+    body = {"fields": _encode_fields(group_doc)}
+    resp = await asyncio.to_thread(rest_session.patch, group_url, json=body)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+
+    active_doc = {
+        "groupId": group_id,
+        "questId": quest_id,
+        "visitedStops": [],
+        "startedAt": datetime.utcnow().isoformat(),
+    }
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    active_body = {"fields": _encode_fields(active_doc)}
+    await asyncio.to_thread(rest_session.patch, active_url, json=active_body)
+
+    return {"groupId": group_id}
+
+
+@app.post("/join-group")
+async def join_group(payload: dict = Body(...)):
+    """Add a user to an existing group quest."""
+    user_id = payload.get("userId")
+    group_id = payload.get("groupId")
+    if not user_id or not group_id:
+        return {"error": "userId and groupId required"}
+
+    project_id = creds.project_id
+    group_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/groups/{group_id}"
+    resp = await asyncio.to_thread(rest_session.get, group_url)
+    if resp.status_code != 200:
+        return {"error": "Group not found"}
+    fields = _decode_document(resp.json())
+
+    members = fields.get("members", [])
+    if user_id not in members:
+        members.append(user_id)
+    progress = fields.get("progress", {})
+    if user_id not in progress:
+        progress[user_id] = []
+
+    fields.update({"members": members, "progress": progress})
+    body = {"fields": _encode_fields(fields)}
+    await asyncio.to_thread(rest_session.patch, group_url, json=body)
+
+    active_doc = {
+        "groupId": group_id,
+        "questId": fields.get("questId"),
+        "visitedStops": progress[user_id],
+        "startedAt": datetime.utcnow().isoformat(),
+    }
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    active_body = {"fields": _encode_fields(active_doc)}
+    await asyncio.to_thread(rest_session.patch, active_url, json=active_body)
+
+    return {"status": "joined", "questId": fields.get("questId")}
+
+
+@app.post("/track-stop-visit")
+async def track_stop_visit(payload: dict = Body(...)):
+    """Track a stop visit for a group quest."""
+    group_id = payload.get("groupId")
+    user_id = payload.get("userId")
+    place_index = payload.get("placeIndex")
+    if group_id is None or user_id is None or place_index is None:
+        return {"error": "groupId, userId and placeIndex required"}
+
+    project_id = creds.project_id
+    group_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/groups/{group_id}"
+    resp = await asyncio.to_thread(rest_session.get, group_url)
+    if resp.status_code != 200:
+        return {"error": "Group not found"}
+    fields = _decode_document(resp.json())
+
+    progress = fields.get("progress", {})
+    user_progress = progress.get(user_id, [])
+    if place_index not in user_progress:
+        user_progress.append(place_index)
+        user_progress.sort()
+        progress[user_id] = user_progress
+        fields["progress"] = progress
+        body = {"fields": _encode_fields(fields)}
+        await asyncio.to_thread(rest_session.patch, group_url, json=body)
+
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    active_resp = await asyncio.to_thread(rest_session.get, active_url)
+    active_fields = {}
+    if active_resp.status_code == 200:
+        active_fields = _decode_document(active_resp.json())
+    active_fields.update({"groupId": group_id, "questId": fields.get("questId"), "visitedStops": user_progress})
+    active_body = {"fields": _encode_fields(active_fields)}
+    await asyncio.to_thread(rest_session.patch, active_url, json=active_body)
+
+    return {"visitedStops": user_progress}
+
+
+@app.get("/active-quest/{user_id}")
+async def get_active_quest(user_id: str):
+    """Return the current active quest doc for the user."""
+    project_id = creds.project_id
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    resp = await asyncio.to_thread(rest_session.get, url)
+    if resp.status_code != 200:
+        return {}
+    return _decode_document(resp.json())

--- a/frontend/src/components/QuestHome.jsx
+++ b/frontend/src/components/QuestHome.jsx
@@ -1,6 +1,19 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { generateQuest } from "../lib/api.js";
+import { generateQuest, createGroupQuest, getActiveQuest, getQuest } from "../lib/api.js";
+
+const _toQuestObj = (doc) => {
+  if (!doc || !doc.fields) return doc;
+  return Object.keys(doc.fields).reduce((acc, k) => {
+    const v = doc.fields[k];
+    if (v.stringValue !== undefined) acc[k] = v.stringValue;
+    else if (v.integerValue !== undefined) acc[k] = parseInt(v.integerValue, 10);
+    else if (v.doubleValue !== undefined) acc[k] = v.doubleValue;
+    else if (v.arrayValue) acc[k] = (v.arrayValue.values || []).map(_toQuestObj);
+    else if (v.mapValue) acc[k] = _toQuestObj({ fields: v.mapValue.fields || {} });
+    return acc;
+  }, {});
+};
 import { getAuth, onAuthStateChanged, signInWithPopup, GoogleAuthProvider } from "firebase/auth";
 import PlaceItem from "./PlaceItem";
 import RouteMap from "./RouteMap";
@@ -26,6 +39,7 @@ const QuestHome = () => {
   const [error, setError] = useState("");
   const [questResult, setQuestResult] = useState(null);
   const [user, setUser] = useState(null);
+  const [resumeData, setResumeData] = useState(null);
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -35,6 +49,23 @@ const QuestHome = () => {
     });
     return () => unsubscribe();
   }, []);
+
+  useEffect(() => {
+    if (!user) return;
+    (async () => {
+      try {
+        const data = await getActiveQuest(user.uid);
+        if (data && data.questId) {
+          const questDoc = await getQuest(data.questId);
+          setResumeData({ quest: _toQuestObj(questDoc), groupId: data.groupId, questId: data.questId });
+        } else {
+          setResumeData(null);
+        }
+      } catch (err) {
+        console.error('Failed to load active quest', err);
+      }
+    })();
+  }, [user]);
 
   const handleLogin = async () => {
     const auth = getAuth();
@@ -74,6 +105,18 @@ const QuestHome = () => {
     }
   };
 
+  const handleStartQuest = async () => {
+    if (!questResult) return;
+    const questId = `${city}_${mood.join('-')}`;
+    try {
+      const { groupId } = await createGroupQuest(user.uid, questId);
+      navigate('/live', { state: { quest: questResult.quest, questId, groupId } });
+    } catch (err) {
+      console.error('Failed to create group', err);
+      setError('Failed to start group quest');
+    }
+  };
+
   const toggleMood = (selectedMood) => {
     if (mood.includes(selectedMood)) {
       setMood(mood.filter((m) => m !== selectedMood));
@@ -87,6 +130,18 @@ const QuestHome = () => {
   return (
     <div className="min-h-screen bg-[#f8fcf8] px-6 py-8 text-[#0e1b0e] font-sans">
       <h1 className="text-[32px] font-bold mb-6 text-center">Create a New Quest</h1>
+      {resumeData && (
+        <div className="mb-6 text-center">
+          <button
+            onClick={() =>
+              navigate('/live', { state: { quest: resumeData.quest, questId: resumeData.questId, groupId: resumeData.groupId } })
+            }
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg"
+          >
+            Resume Quest
+          </button>
+        </div>
+      )}
 
       {!user ? (
         <div className="text-center space-y-4">
@@ -163,14 +218,7 @@ const QuestHome = () => {
               />
 
               <button
-                onClick={() =>
-                  navigate('/live', {
-                    state: {
-                      quest: questResult.quest,
-                      questId: `${city}_${mood.join('-')}`,
-                    },
-                  })
-                }
+                onClick={handleStartQuest}
                 className="mt-4 w-full bg-[#14b714] text-white py-2 rounded-lg font-bold hover:bg-[#0fa50f] transition"
               >
                 Start Quest

--- a/frontend/src/components/QuestLivePage.jsx
+++ b/frontend/src/components/QuestLivePage.jsx
@@ -2,13 +2,16 @@ import React, { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
 import LiveQuestMap from "./LiveQuestMap";
 import { getAuth } from "firebase/auth";
-import { trackVisit, getUserQuests, completeQuest } from "../lib/api";
+import { trackVisit, getUserQuests, completeQuest, joinGroup, trackStopVisit } from "../lib/api";
+import { doc, onSnapshot } from "firebase/firestore";
+import { db } from "../firebase";
 
 
 export default function QuestLivePage() {
   const location = useLocation();
   const quest = location.state?.quest;
   const questId = location.state?.questId;
+  const groupId = location.state?.groupId || new URLSearchParams(location.search).get('groupId');
 
   const [userLocation, setUserLocation] = useState(null);
   const [stops, setStops] = useState([]);
@@ -41,8 +44,24 @@ export default function QuestLivePage() {
     setStops([{ lat: userLocation.lat, lng: userLocation.lng }, ...questStops]);
   }, [quest, userLocation]);
 
-  // Load progress from backend
+  // Join group and listen for progress
   useEffect(() => {
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user || !groupId) return;
+    joinGroup(user.uid, groupId).catch((e) => console.error('join failed', e));
+    const unsub = onSnapshot(doc(db, 'groups', groupId), (snap) => {
+      const data = snap.data();
+      if (data && data.progress && data.progress[user.uid]) {
+        setVisitedIndices(data.progress[user.uid]);
+      }
+    });
+    return () => unsub();
+  }, [groupId]);
+
+  // Load personal progress when not in group
+  useEffect(() => {
+    if (groupId) return;
     const auth = getAuth();
     const user = auth.currentUser;
     if (!user || !questId) return;
@@ -57,7 +76,7 @@ export default function QuestLivePage() {
         console.error('Failed to load progress', err);
       }
     })();
-  }, [quest]);
+  }, [quest, groupId]);
 
   const currentStopIndex = visitedIndices.length;
   const allVisited = visitedIndices.length >= (quest?.places?.length || 0);
@@ -93,8 +112,13 @@ export default function QuestLivePage() {
 
     if (!questId) return;
     try {
-      const res = await trackVisit(user.uid, questId, visitedIndices.length);
-      setVisitedIndices(res.visitedIndices || []);
+      if (groupId) {
+        const res = await trackStopVisit(groupId, user.uid, visitedIndices.length);
+        setVisitedIndices(res.visitedStops || res.visitedIndices || []);
+      } else {
+        const res = await trackVisit(user.uid, questId, visitedIndices.length);
+        setVisitedIndices(res.visitedIndices || []);
+      }
     } catch (err) {
       console.error('Failed to track visit', err);
     }
@@ -173,14 +197,17 @@ export default function QuestLivePage() {
 
         <main className="px-10 py-5 flex flex-col max-w-4xl mx-auto w-full">
           <div className="flex flex-wrap justify-between gap-3 p-4">
-            <div className="flex flex-col gap-3 min-w-72">
-              <p className="text-2xl font-bold text-[#0e1b0e]">
-                {quest?.title || "Your Quest"}
-              </p>
-              <p className="text-sm text-[#4e974e]">
-                {quest?.questText || "Embark on your adventure"}
-              </p>
-            </div>
+          <div className="flex flex-col gap-3 min-w-72">
+            <p className="text-2xl font-bold text-[#0e1b0e]">
+              {quest?.title || "Your Quest"}
+            </p>
+            <p className="text-sm text-[#4e974e]">
+              {quest?.questText || "Embark on your adventure"}
+            </p>
+            {groupId && (
+              <p className="text-xs text-blue-700 break-all">Invite Link: {`${window.location.origin}/live?groupId=${groupId}`}</p>
+            )}
+          </div>
             <button
               onClick={() => window.location.assign('/home')}
               className="h-8 px-4 rounded-full bg-[#e7f3e7] text-sm text-[#0e1b0e]"

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -102,3 +102,55 @@ export async function trackVisit(userId, questId, placeIndex) {
   return resp.json();
 }
 
+
+export async function createGroupQuest(userId, questId) {
+  const resp = await fetch(`${BASE_URL}/create-group-quest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, questId })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to create group');
+  }
+  return resp.json();
+}
+
+export async function joinGroup(userId, groupId) {
+  const resp = await fetch(`${BASE_URL}/join-group`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, groupId })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to join group');
+  }
+  return resp.json();
+}
+
+export async function trackStopVisit(groupId, userId, placeIndex) {
+  const resp = await fetch(`${BASE_URL}/track-stop-visit`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ groupId, userId, placeIndex })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to track stop');
+  }
+  return resp.json();
+}
+
+export async function getActiveQuest(userId) {
+  const resp = await fetch(`${BASE_URL}/active-quest/${userId}`);
+  if (!resp.ok) {
+    return null;
+  }
+  return resp.json();
+}
+
+export async function getQuest(questId) {
+  const resp = await fetch(`${BASE_URL}/get-quest/${questId}`);
+  if (!resp.ok) {
+    throw new Error('Failed to fetch quest');
+  }
+  return resp.json();
+}


### PR DESCRIPTION
## Summary
- add backend endpoints for group quests and active quest retrieval
- extend frontend API helper with group functions
- show Resume Quest prompt on home
- create group on quest start and track group progress in real time

## Testing
- `npm run lint`
- `python -m py_compile backend/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6881177da2dc832198ba09841e0f1757