### PR TITLE
Enable group quest polish

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -347,6 +347,28 @@ async def complete_quest(payload: dict = Body(...)):
         print("Firestore REST error", resp.text)
         resp.raise_for_status()
 
+    if payload.get("public"):
+        feed_id = f"{quest_id}_{user_id}"
+        feed_doc = {
+            "city": payload.get("city"),
+            "mood": payload.get("mood"),
+            "displayName": payload.get("displayName"),
+            "imageUrl": payload.get("imageUrl"),
+            "questText": payload.get("questText"),
+            "completedAt": timestamp,
+            "userId": user_id,
+            "questId": quest_id,
+            "title": payload.get("title"),
+        }
+        feed_url = (
+            f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/community_quests/{feed_id}"
+        )
+        feed_body = {"fields": _encode_fields(feed_doc)}
+        fr = await asyncio.to_thread(rest_session.patch, feed_url, json=feed_body)
+        if fr.status_code != 200:
+            print("Firestore REST error", fr.text)
+            fr.raise_for_status()
+
     return {"status": "completed", "newXP": xp, "badges": badges}
 
 
@@ -549,6 +571,8 @@ async def get_user_quests(userId: str = Query(...)):
         if not doc:
             continue
         obj = _decode_document(doc)
+        if obj.get("visible") is False:
+            continue
         obj["id"] = doc["name"].split("/")[-1]
         results.append(obj)
     return {"quests": results}
@@ -698,4 +722,415 @@ async def get_directions(payload: dict = Body(...)):
         ],
         "totalTime": "22 mins",
     }
+
+
+@app.post("/create-group-quest")
+async def create_group_quest(payload: dict = Body(...)):
+    """Create a shared group quest and set user active state."""
+    user_id = payload.get("userId")
+    quest_id = payload.get("questId")
+    display_name = payload.get("displayName")
+    if not user_id or not quest_id:
+        return {"error": "userId and questId required"}
+
+    project_id = creds.project_id
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    active_resp = await asyncio.to_thread(rest_session.get, active_url)
+    if active_resp.status_code == 200:
+        active_fields = _decode_document(active_resp.json())
+        if active_fields.get("status") != "completed":
+            return {"error": "active quest already"}
+
+    group_id = hashlib.sha1(f"{user_id}-{quest_id}-{datetime.utcnow()}".encode()).hexdigest()[:8]
+
+    member_entry = {"userId": user_id, "displayName": display_name or user_id}
+    group_doc = {
+        "questId": quest_id,
+        "members": [member_entry],
+        "progress": {user_id: []},
+        "invitedBy": user_id,
+        "completed": False,
+        "createdAt": datetime.utcnow().isoformat(),
+    }
+    group_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/groups/{group_id}"
+    body = {"fields": _encode_fields(group_doc)}
+    resp = await asyncio.to_thread(rest_session.patch, group_url, json=body)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+
+    active_doc = {
+        "groupId": group_id,
+        "questId": quest_id,
+        "status": "active",
+        "visitedStops": [],
+        "startedAt": datetime.utcnow().isoformat(),
+    }
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    active_body = {"fields": _encode_fields(active_doc)}
+    await asyncio.to_thread(rest_session.patch, active_url, json=active_body)
+
+    return {"groupId": group_id}
+
+
+@app.post("/join-group")
+async def join_group(payload: dict = Body(...)):
+    """Add a user to an existing group quest."""
+    user_id = payload.get("userId")
+    group_id = payload.get("groupId")
+    display_name = payload.get("displayName")
+    if not user_id or not group_id:
+        return {"error": "userId and groupId required"}
+
+    project_id = creds.project_id
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    active_resp = await asyncio.to_thread(rest_session.get, active_url)
+    if active_resp.status_code == 200:
+        active_fields = _decode_document(active_resp.json())
+        if active_fields.get("status") != "completed" and active_fields.get("groupId") not in (None, group_id):
+            return {"error": "active quest already"}
+    group_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/groups/{group_id}"
+    resp = await asyncio.to_thread(rest_session.get, group_url)
+    if resp.status_code != 200:
+        return {"error": "Group not found"}
+    fields = _decode_document(resp.json())
+    if fields.get("completed"):
+        return {"error": "Group completed"}
+
+    members = fields.get("members", [])
+    if not any(m.get("userId") == user_id for m in members):
+        members.append({"userId": user_id, "displayName": display_name or user_id})
+    progress = fields.get("progress", {})
+    if user_id not in progress:
+        progress[user_id] = []
+
+    fields.update({"members": members, "progress": progress})
+    body = {"fields": _encode_fields(fields)}
+    await asyncio.to_thread(rest_session.patch, group_url, json=body)
+
+    active_doc = {
+        "groupId": group_id,
+        "questId": fields.get("questId"),
+        "status": "active",
+        "visitedStops": progress[user_id],
+        "startedAt": datetime.utcnow().isoformat(),
+    }
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    active_body = {"fields": _encode_fields(active_doc)}
+    await asyncio.to_thread(rest_session.patch, active_url, json=active_body)
+
+    return {"status": "joined", "questId": fields.get("questId")}
+
+
+@app.post("/track-stop-visit")
+async def track_stop_visit(payload: dict = Body(...)):
+    """Track a stop visit for a group quest."""
+    group_id = payload.get("groupId")
+    user_id = payload.get("userId")
+    place_index = payload.get("placeIndex")
+    if group_id is None or user_id is None or place_index is None:
+        return {"error": "groupId, userId and placeIndex required"}
+
+    project_id = creds.project_id
+    group_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/groups/{group_id}"
+    resp = await asyncio.to_thread(rest_session.get, group_url)
+    if resp.status_code != 200:
+        return {"error": "Group not found"}
+    fields = _decode_document(resp.json())
+    if fields.get("completed"):
+        return {"error": "Group completed"}
+    if not any(m.get("userId") == user_id for m in fields.get("members", [])):
+        return {"error": "Not a group member"}
+
+    progress = fields.get("progress", {})
+    user_progress = progress.get(user_id, [])
+    if place_index not in user_progress:
+        user_progress.append(place_index)
+        user_progress.sort()
+        progress[user_id] = user_progress
+        fields["progress"] = progress
+        body = {"fields": _encode_fields(fields)}
+        await asyncio.to_thread(rest_session.patch, group_url, json=body)
+
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    active_resp = await asyncio.to_thread(rest_session.get, active_url)
+    active_fields = {}
+    if active_resp.status_code == 200:
+        active_fields = _decode_document(active_resp.json())
+    active_fields.update({
+        "groupId": group_id,
+        "questId": fields.get("questId"),
+        "status": "active",
+        "visitedStops": user_progress,
+    })
+    active_body = {"fields": _encode_fields(active_fields)}
+    await asyncio.to_thread(rest_session.patch, active_url, json=active_body)
+
+    return {"visitedStops": user_progress}
+
+
+@app.post("/complete-group-quest")
+async def complete_group_quest(payload: dict = Body(...)):
+    """Mark a group quest as completed by a user."""
+    group_id = payload.get("groupId")
+    user_id = payload.get("userId")
+    if not group_id or not user_id:
+        return {"error": "groupId and userId required"}
+
+    project_id = creds.project_id
+    group_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/groups/{group_id}"
+    resp = await asyncio.to_thread(rest_session.get, group_url)
+    if resp.status_code != 200:
+        return {"error": "Group not found"}
+    fields = _decode_document(resp.json())
+    if fields.get("completed"):
+        return {"error": "Group already completed"}
+    if not any(m.get("userId") == user_id for m in fields.get("members", [])):
+        return {"error": "Not a group member"}
+    fields["completed"] = True
+    body = {"fields": _encode_fields(fields)}
+    await asyncio.to_thread(rest_session.patch, group_url, json=body)
+
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    active_fields = {
+        "groupId": group_id,
+        "questId": fields.get("questId"),
+        "status": "completed",
+    }
+    active_body = {"fields": _encode_fields(active_fields)}
+    await asyncio.to_thread(rest_session.patch, active_url, json=active_body)
+
+    return {"status": "completed"}
+
+
+@app.get("/active-quest/{user_id}")
+async def get_active_quest(user_id: str):
+    """Return the current active quest doc for the user."""
+    project_id = creds.project_id
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    resp = await asyncio.to_thread(rest_session.get, url)
+    if resp.status_code != 200:
+        return {}
+    active = _decode_document(resp.json())
+
+    quest_ok = True
+    if active.get("questId"):
+        qurl = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/quests/{active['questId']}"
+        qresp = await asyncio.to_thread(rest_session.get, qurl)
+        quest_ok = qresp.status_code == 200
+
+    group_ok = True
+    if active.get("groupId"):
+        gurl = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/groups/{active['groupId']}"
+        gresp = await asyncio.to_thread(rest_session.get, gurl)
+        if gresp.status_code != 200:
+            group_ok = False
+        else:
+            gdata = _decode_document(gresp.json())
+            group_ok = not gdata.get("completed")
+
+    if not quest_ok or not group_ok:
+        await asyncio.to_thread(rest_session.delete, url)
+        return {}
+
+    return active
+
+
+@app.post("/leave-group")
+async def leave_group(payload: dict = Body(...)):
+    """Remove a user from a group and clear their active quest."""
+    user_id = payload.get("userId")
+    group_id = payload.get("groupId")
+    if not user_id or not group_id:
+        return {"error": "userId and groupId required"}
+
+    project_id = creds.project_id
+    group_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/groups/{group_id}"
+    resp = await asyncio.to_thread(rest_session.get, group_url)
+    if resp.status_code == 200:
+        fields = _decode_document(resp.json())
+        members = [m for m in fields.get("members", []) if m.get("userId") != user_id]
+        progress = fields.get("progress", {})
+        progress.pop(user_id, None)
+        fields.update({"members": members, "progress": progress})
+        body = {"fields": _encode_fields(fields)}
+        await asyncio.to_thread(rest_session.patch, group_url, json=body)
+
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    await asyncio.to_thread(rest_session.delete, active_url)
+    return {"status": "left"}
+
+
+@app.post("/report-quest")
+async def report_quest(payload: dict = Body(...)):
+    """Receive a quest report and store in Firestore."""
+    user_id = payload.get("userId")
+    quest_id = payload.get("questId")
+    reason = payload.get("reason")
+    if not user_id or not quest_id or not reason:
+        return {"error": "userId, questId and reason required"}
+
+    project_id = creds.project_id
+    doc_id = f"{quest_id}_{user_id}"
+    report = {
+        "userId": user_id,
+        "questId": quest_id,
+        "reason": reason,
+        "city": payload.get("city"),
+        "mood": payload.get("mood"),
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/quest_reports/{doc_id}"
+    body = {"fields": _encode_fields(report)}
+    resp = await asyncio.to_thread(rest_session.patch, url, json=body)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+    return {"status": "reported"}
+
+
+@app.get("/get-quest-reports")
+async def get_quest_reports():
+    """Return recent quest reports for admin review."""
+    project_id = creds.project_id
+    url = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/quest_reports:runQuery"
+    )
+    query = {
+        "structuredQuery": {
+            "from": [{"collectionId": "quest_reports"}],
+            "orderBy": [{"field": {"fieldPath": "timestamp"}, "direction": "DESCENDING"}],
+            "limit": 20,
+        }
+    }
+    resp = await asyncio.to_thread(rest_session.post, url, json=query)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+    raw = resp.json()
+    results = []
+    for item in raw:
+        doc = item.get("document")
+        if not doc:
+            continue
+        obj = _decode_document(doc)
+        obj["id"] = doc["name"].split("/")[-1]
+        results.append(obj)
+    return {"reports": results}
+
+
+@app.post("/toggle-quest-visibility")
+async def toggle_quest_visibility(payload: dict = Body(...)):
+    """Hide or show a community quest."""
+    quest_id = payload.get("questId")
+    user_id = payload.get("userId")
+    visible = payload.get("visible", True)
+    if not quest_id or not user_id:
+        return {"error": "questId and userId required"}
+
+    project_id = creds.project_id
+    doc_id = f"{quest_id}_{user_id}"
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/community_quests/{doc_id}"
+    body = {"fields": _encode_fields({"visible": visible})}
+    resp = await asyncio.to_thread(rest_session.patch, url, json=body)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+    return {"status": "updated"}
+
+
+@app.get("/get-community-quests")
+async def get_community_quests():
+    """Return recently completed public quests."""
+    project_id = creds.project_id
+    url = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/community_quests:runQuery"
+    )
+    query = {
+        "structuredQuery": {
+            "from": [{"collectionId": "community_quests"}],
+            "orderBy": [{"field": {"fieldPath": "completedAt"}, "direction": "DESCENDING"}],
+            "limit": 20,
+        }
+    }
+    resp = await asyncio.to_thread(rest_session.post, url, json=query)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+    raw = resp.json()
+    results = []
+    for item in raw:
+        doc = item.get("document")
+        if not doc:
+            continue
+        obj = _decode_document(doc)
+        if obj.get("visible") is False:
+            continue
+        obj["id"] = doc["name"].split("/")[-1]
+        results.append(obj)
+    return {"quests": results}
+
+@app.post("/create-checkout-session")
+async def create_checkout_session(payload: dict = Body(...)):
+    """Return a Stripe Checkout URL or mock URL."""
+    user_id = payload.get("userId")
+    email = payload.get("email")
+    if not user_id or not email:
+        return {"error": "userId and email required"}
+
+    base_url = payload.get("baseUrl", "https://example.com")
+    success = f"{base_url}/payment-success?userId={user_id}&session_id={{CHECKOUT_SESSION_ID}}"
+    cancel = f"{base_url}/payment-failed"
+    stripe_key = os.getenv("STRIPE_SECRET_KEY")
+    if stripe_key:
+        try:
+            import stripe
+            stripe.api_key = stripe_key
+            session = await asyncio.to_thread(
+                stripe.checkout.Session.create,
+                payment_method_types=["card"],
+                mode="payment",
+                line_items=[{"price": os.getenv("STRIPE_PRICE_ID", "price_123"), "quantity": 1}],
+                customer_email=email,
+                success_url=success,
+                cancel_url=cancel,
+            )
+            return {"url": session.url}
+        except Exception as e:
+            print("Stripe error", e)
+            return {"error": "stripe failed"}
+    # Fallback mock URL
+    return {"url": success.replace("{CHECKOUT_SESSION_ID}", "mock")}
+
+
+@app.get("/validate-premium/{user_id}")
+async def validate_premium(user_id: str, session_id: str | None = Query(None)):
+    """Check premium flag and optionally verify checkout session."""
+    project_id = creds.project_id
+    user_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/users/{user_id}"
+    resp = await asyncio.to_thread(rest_session.get, user_url)
+    fields = {}
+    if resp.status_code == 200:
+        fields = _decode_document(resp.json())
+    premium = fields.get("premium") is True
+
+    if not premium and session_id:
+        stripe_key = os.getenv("STRIPE_SECRET_KEY")
+        if stripe_key and session_id != "mock":
+            try:
+                import stripe
+                stripe.api_key = stripe_key
+                sess = await asyncio.to_thread(stripe.checkout.Session.retrieve, session_id)
+                premium = sess.get("payment_status") == "paid"
+            except Exception as e:
+                print("Stripe verify error", e)
+                premium = False
+        elif session_id == "mock":
+            premium = True
+        if premium:
+            fields["premium"] = True
+            body = {"fields": _encode_fields(fields)}
+            await asyncio.to_thread(rest_session.patch, user_url, json=body)
+
+    return {"premium": premium}
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,10 @@
 // src/App.jsx
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, useNavigate, useLocation } from "react-router-dom";
+import { useEffect } from "react";
+import { onAuthStateChanged, getAuth } from "firebase/auth";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "./firebase";
+import { getActiveQuest, getQuest, leaveGroup } from "./lib/api";
 import LandingPage from "./components/LandingPage";
 import QuestHome from "./components/QuestHome";
 import QuestDetails from "./components/QuestDetails";
@@ -11,9 +16,39 @@ import QuestLivePage from "./components/QuestLivePage";
 import QuestPlusPage from "./components/QuestPlusPage";
 import PaymentSuccess from "./components/PaymentSuccess";
 import PaymentFailed from "./components/PaymentFailed";
+import CommunityFeed from "./components/CommunityFeed";
+import AdminDashboard from "./components/AdminDashboard";
 
 
 function App() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  useEffect(() => {
+    const auth = getAuth();
+    const unsub = onAuthStateChanged(auth, async (user) => {
+      if (!user) return;
+      try {
+        const data = await getActiveQuest(user.uid);
+        if (data && data.questId && data.status !== 'completed') {
+          const quest = await getQuest(data.questId).catch(() => null);
+          let groupOk = true;
+          if (data.groupId) {
+            const snap = await getDoc(doc(db, 'groups', data.groupId));
+            groupOk = snap.exists() && !snap.data().completed;
+          }
+          if (quest && groupOk && location.pathname !== '/live') {
+            navigate('/live', { state: { quest, questId: data.questId, groupId: data.groupId } });
+          } else if (!quest || !groupOk) {
+            if (data.groupId) await leaveGroup(data.groupId, user.uid);
+          }
+        }
+      } catch (err) {
+        console.error('resume failed', err);
+      }
+    });
+    return () => unsub();
+  }, [location.pathname, navigate]);
+
   return (
     <>
       <Header />
@@ -25,6 +60,8 @@ function App() {
         <Route path="/history" element={<QuestHistory />} />
         <Route path="/profile" element={<Profile />} />
         <Route path="/live" element={<QuestLivePage />} />
+        <Route path="/community" element={<CommunityFeed />} />
+        <Route path="/admin" element={<AdminDashboard />} />
         <Route path="/quest-plus" element={<QuestPlusPage />} />
         <Route path="/payment-success" element={<PaymentSuccess />} />
         <Route path="/payment-failed" element={<PaymentFailed />} />

--- a/frontend/src/components/AdminDashboard.jsx
+++ b/frontend/src/components/AdminDashboard.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { getQuestReports, toggleQuestVisibility } from '../lib/api';
+
+export default function AdminDashboard() {
+  const [reports, setReports] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await getQuestReports();
+        setReports(data.reports || []);
+      } catch (err) {
+        console.error('Failed to load reports', err);
+        setError('Failed to load reports');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const handleHide = async (r) => {
+    if (!window.confirm('Hide this quest from community feed?')) return;
+    try {
+      await toggleQuestVisibility(r.questId, r.userId, false);
+      alert('Quest hidden');
+    } catch (err) {
+      console.error('Failed to update visibility', err);
+    }
+  };
+
+  if (loading) return <div className="p-6">Loading...</div>;
+  if (error) return <div className="p-6 text-red-600">{error}</div>;
+
+  return (
+    <div className="min-h-screen bg-[#f8fcf8] px-6 py-8 text-[#0e1b0e] font-sans">
+      <h1 className="text-2xl font-bold mb-6">Admin Dashboard</h1>
+      <div className="space-y-4">
+        {reports.map((r) => (
+          <div key={r.id} className="flex justify-between bg-white p-4 rounded-lg shadow">
+            <div className="text-sm">
+              <p className="font-semibold">{r.city} - {r.mood}</p>
+              <p className="text-xs text-gray-600">By {r.userId}</p>
+              <p className="text-xs">Reason: {r.reason}</p>
+            </div>
+            <button onClick={() => handleHide(r)} className="h-8 px-3 rounded bg-red-500 text-white text-xs">Hide Quest</button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/CommunityFeed.jsx
+++ b/frontend/src/components/CommunityFeed.jsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import { getCommunityQuests, reportQuest } from '../lib/api';
+import { getAuth } from 'firebase/auth';
+
+export default function CommunityFeed() {
+  const [quests, setQuests] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await getCommunityQuests();
+        setQuests(data.quests || []);
+      } catch (err) {
+        console.error('Failed to load feed', err);
+        setError('Failed to load feed');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const handleReport = async (quest) => {
+    const reason = window.prompt('Reason for report?');
+    if (!reason) return;
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user) return alert('You must be logged in');
+    try {
+      await reportQuest(user.uid, quest.questId, reason, quest.city, quest.mood);
+      alert('Report submitted');
+    } catch (err) {
+      console.error('Failed to report quest', err);
+      alert('Failed to report quest');
+    }
+  };
+
+  if (loading) return <div className="p-6">Loading...</div>;
+  if (error) return <div className="p-6 text-red-600">{error}</div>;
+  if (quests.length === 0) return <div className="p-6">No public quests yet.</div>;
+
+  return (
+    <div className="min-h-screen bg-[#f8fcf8] px-6 py-8 text-[#0e1b0e] font-sans">
+      <h1 className="text-2xl font-bold mb-6">Community Feed</h1>
+      <div className="space-y-4">
+        {quests.map((q) => (
+          <div key={q.id} className="flex gap-4 bg-white p-4 rounded-lg shadow">
+            <img src={q.imageUrl || 'https://placehold.co/200'} alt="" className="w-32 h-20 object-cover rounded" />
+            <div className="flex-1 text-sm">
+              <h2 className="font-semibold">{q.title || 'Quest'}</h2>
+              <p className="text-gray-600">{q.city} - {q.mood}</p>
+              <p className="text-gray-500 text-xs">{new Date(q.completedAt).toLocaleString()}</p>
+              {q.displayName && <p className="text-xs">By {q.displayName}</p>}
+              <button onClick={() => handleReport(q)} className="text-red-500 underline text-xs mt-1">Report</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/GroupMemberList.jsx
+++ b/frontend/src/components/GroupMemberList.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function GroupMemberList({ members = [], progress = {}, total = 0 }) {
+  return (
+    <ul className="text-sm space-y-1">
+      {members.map((m) => {
+        const count = (progress[m.userId] || []).length;
+        return (
+          <li key={m.userId} className="flex justify-between">
+            <span>{m.displayName || m.userId}</span>
+            <span>{count}/{total}</span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,9 +1,20 @@
 // src/components/Header.jsx
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
+import { getAuth, onAuthStateChanged } from "firebase/auth";
 
 const Header = () => {
   const { pathname } = useLocation();
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const auth = getAuth();
+    return onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      setIsAdmin(u?.email === 'admin@roamio.app');
+    });
+  }, []);
 
   const linkClass = (path) =>
     `text-sm font-medium transition px-2 py-1 rounded ${
@@ -18,7 +29,14 @@ const Header = () => {
       <nav className="flex gap-4">
         <Link to="/home" className={linkClass("/home")}>Home</Link>
         <Link to="/history" className={linkClass("/history")}>History</Link>
-        <Link to="/profile" className={linkClass("/profile")}>Profile</Link>
+        <Link to="/community" className={linkClass("/community")}>Community</Link>
+        <Link to="/quest-plus" className={linkClass("/quest-plus")}>Quest+</Link>
+        {isAdmin && (
+          <Link to="/admin" className={linkClass("/admin")}>Admin</Link>
+        )}
+        {user && (
+          <Link to="/profile" className={linkClass("/profile")}>Profile</Link>
+        )}
       </nav>
     </header>
   );

--- a/frontend/src/components/PaymentSuccess.jsx
+++ b/frontend/src/components/PaymentSuccess.jsx
@@ -1,12 +1,31 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import { validatePremium } from '../lib/api';
 
-const PaymentSuccess = () => (
-  <div className="min-h-screen flex items-center justify-center bg-[#f8fcf8] px-6 py-10 text-center">
-    <div>
-      <h1 className="text-3xl font-bold text-green-700 mb-4">Payment Successful</h1>
-      <p className="text-[#0e1b0e]">Welcome to Quest+! Enjoy your new adventures.</p>
+const PaymentSuccess = () => {
+  const [params] = useSearchParams();
+  const [status, setStatus] = useState('Activating...');
+
+  useEffect(() => {
+    const uid = params.get('userId');
+    const session = params.get('session_id');
+    if (uid && session) {
+      validatePremium(uid, session)
+        .then(() => setStatus('Quest+ Activated!'))
+        .catch(() => setStatus('Validation failed'));
+    } else {
+      setStatus('Quest+ Activated!');
+    }
+  }, [params]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[#f8fcf8] px-6 py-10 text-center">
+      <div>
+        <h1 className="text-3xl font-bold text-green-700 mb-4">Payment Successful</h1>
+        <p className="text-[#0e1b0e]">{status}</p>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default PaymentSuccess;

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -54,7 +54,14 @@ const Profile = () => {
         {stats.mostCity && <p>Most visited city: {stats.mostCity}</p>}
         {stats.longest > 0 && <p>Longest quest: {stats.longest} stops</p>}
       </div>
-      <PostcardGallery />
+      {premium ? (
+        <PostcardGallery />
+      ) : (
+        <div className="text-center space-y-2">
+          <p className="text-sm">Quest+ membership required to view your full postcard history.</p>
+          <a href="/quest-plus" className="text-blue-600 underline">Upgrade to Quest+</a>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/QuestHome.jsx
+++ b/frontend/src/components/QuestHome.jsx
@@ -1,6 +1,21 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { generateQuest } from "../lib/api.js";
+import { generateQuest, createGroupQuest, getActiveQuest, getQuest, leaveGroup, validatePremium } from "../lib/api.js";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "../firebase";
+
+const _toQuestObj = (doc) => {
+  if (!doc || !doc.fields) return doc;
+  return Object.keys(doc.fields).reduce((acc, k) => {
+    const v = doc.fields[k];
+    if (v.stringValue !== undefined) acc[k] = v.stringValue;
+    else if (v.integerValue !== undefined) acc[k] = parseInt(v.integerValue, 10);
+    else if (v.doubleValue !== undefined) acc[k] = v.doubleValue;
+    else if (v.arrayValue) acc[k] = (v.arrayValue.values || []).map(_toQuestObj);
+    else if (v.mapValue) acc[k] = _toQuestObj({ fields: v.mapValue.fields || {} });
+    return acc;
+  }, {});
+};
 import { getAuth, onAuthStateChanged, signInWithPopup, GoogleAuthProvider } from "firebase/auth";
 import PlaceItem from "./PlaceItem";
 import RouteMap from "./RouteMap";
@@ -26,15 +41,54 @@ const QuestHome = () => {
   const [error, setError] = useState("");
   const [questResult, setQuestResult] = useState(null);
   const [user, setUser] = useState(null);
+  const [premium, setPremium] = useState(false);
+  const [resumeData, setResumeData] = useState(null);
   const navigate = useNavigate();
 
   useEffect(() => {
     const auth = getAuth();
-    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
       setUser(firebaseUser);
+      if (firebaseUser) {
+        try {
+          const res = await validatePremium(firebaseUser.uid);
+          setPremium(!!res.premium);
+        } catch (err) {
+          console.error('premium check failed', err);
+        }
+      } else {
+        setPremium(false);
+      }
     });
     return () => unsubscribe();
   }, []);
+
+  useEffect(() => {
+    if (!user) return;
+    (async () => {
+      try {
+        const data = await getActiveQuest(user.uid);
+        if (data && data.questId && data.status !== 'completed') {
+          const questDoc = await getQuest(data.questId).catch(() => null);
+          let groupOk = true;
+          if (data.groupId) {
+            const snap = await getDoc(doc(db, 'groups', data.groupId));
+            groupOk = snap.exists() && !snap.data().completed;
+          }
+          if (questDoc && groupOk) {
+            setResumeData({ quest: _toQuestObj(questDoc), groupId: data.groupId, questId: data.questId, status: data.status });
+          } else {
+            if (data.groupId) await leaveGroup(data.groupId, user.uid);
+            setResumeData(null);
+          }
+        } else {
+          setResumeData(null);
+        }
+      } catch (err) {
+        console.error('Failed to load active quest', err);
+      }
+    })();
+  }, [user]);
 
   const handleLogin = async () => {
     const auth = getAuth();
@@ -50,6 +104,11 @@ const QuestHome = () => {
   const handleGenerate = async () => {
     setError("");
     setQuestResult(null);
+
+    if (!premium) {
+      navigate('/quest-plus');
+      return;
+    }
 
     if (!user) {
       setError("You must be signed in to generate a quest.");
@@ -74,6 +133,22 @@ const QuestHome = () => {
     }
   };
 
+  const handleStartQuest = async () => {
+    if (!premium) {
+      navigate('/quest-plus');
+      return;
+    }
+    if (!questResult) return;
+    const questId = `${city}_${mood.join('-')}`;
+    try {
+      const { groupId } = await createGroupQuest(user.uid, questId, user.displayName);
+      navigate('/live', { state: { quest: questResult.quest, questId, groupId } });
+    } catch (err) {
+      console.error('Failed to create group', err);
+      setError('Failed to start group quest');
+    }
+  };
+
   const toggleMood = (selectedMood) => {
     if (mood.includes(selectedMood)) {
       setMood(mood.filter((m) => m !== selectedMood));
@@ -87,6 +162,18 @@ const QuestHome = () => {
   return (
     <div className="min-h-screen bg-[#f8fcf8] px-6 py-8 text-[#0e1b0e] font-sans">
       <h1 className="text-[32px] font-bold mb-6 text-center">Create a New Quest</h1>
+      {resumeData && (
+        <div className="mb-6 text-center">
+          <button
+            onClick={() =>
+              navigate('/live', { state: { quest: resumeData.quest, questId: resumeData.questId, groupId: resumeData.groupId } })
+            }
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg"
+          >
+            Resume Quest
+          </button>
+        </div>
+      )}
 
       {!user ? (
         <div className="text-center space-y-4">
@@ -163,18 +250,25 @@ const QuestHome = () => {
               />
 
               <button
-                onClick={() =>
-                  navigate('/live', {
-                    state: {
-                      quest: questResult.quest,
-                      questId: `${city}_${mood.join('-')}`,
-                    },
-                  })
-                }
-                className="mt-4 w-full bg-[#14b714] text-white py-2 rounded-lg font-bold hover:bg-[#0fa50f] transition"
+                onClick={handleStartQuest}
+                disabled={!!resumeData}
+                className={`mt-4 w-full py-2 rounded-lg font-bold transition text-white ${
+                  resumeData ? 'bg-gray-400 cursor-not-allowed' : 'bg-[#14b714] hover:bg-[#0fa50f]'
+                }`}
               >
                 Start Quest
               </button>
+              {!premium && (
+                <p className="text-center text-xs mt-1">
+                  Quest+ required to start quests.{' '}
+                  <a href="/quest-plus" className="text-blue-600 underline">Upgrade</a>
+                </p>
+              )}
+              {resumeData && (
+                <p className="text-center text-sm text-red-600 mt-1">
+                  You have a quest in progress.
+                </p>
+              )}
 
             </div>
           )}

--- a/frontend/src/components/QuestLivePage.jsx
+++ b/frontend/src/components/QuestLivePage.jsx
@@ -1,18 +1,27 @@
 import React, { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import LiveQuestMap from "./LiveQuestMap";
+import GroupMemberList from "./GroupMemberList";
 import { getAuth } from "firebase/auth";
-import { trackVisit, getUserQuests, completeQuest } from "../lib/api";
+import { trackVisit, getUserQuests, completeQuest, joinGroup, trackStopVisit, completeGroupQuest, leaveGroup, reportQuest } from "../lib/api";
+import { doc, onSnapshot } from "firebase/firestore";
+import { db } from "../firebase";
 
 
 export default function QuestLivePage() {
   const location = useLocation();
+  const navigate = useNavigate();
   const quest = location.state?.quest;
   const questId = location.state?.questId;
+  const groupId = location.state?.groupId || new URLSearchParams(location.search).get('groupId');
 
   const [userLocation, setUserLocation] = useState(null);
   const [stops, setStops] = useState([]);
   const [visitedIndices, setVisitedIndices] = useState([]);
+  const [groupData, setGroupData] = useState(null);
+  const [activityMsg, setActivityMsg] = useState("");
+  const [copied, setCopied] = useState(false);
+  const [showComplete, setShowComplete] = useState(false);
   const [etaText, setEtaText] = useState("");
   const [saving, setSaving] = useState(false);
   const [completeMsg, setCompleteMsg] = useState("");
@@ -41,8 +50,40 @@ export default function QuestLivePage() {
     setStops([{ lat: userLocation.lat, lng: userLocation.lng }, ...questStops]);
   }, [quest, userLocation]);
 
-  // Load progress from backend
+  // Join group and listen for progress
   useEffect(() => {
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user || !groupId) return;
+    joinGroup(user.uid, groupId, user.displayName).catch((e) => console.error('join failed', e));
+    let prev = null;
+    const unsub = onSnapshot(doc(db, 'groups', groupId), (snap) => {
+      const data = snap.data();
+      if (!data) return;
+      setGroupData(data);
+      if (data.progress && data.progress[user.uid]) {
+        setVisitedIndices(data.progress[user.uid]);
+      }
+      if (prev && data.progress) {
+        Object.keys(data.progress).forEach((uid) => {
+          if (uid === user.uid) return;
+          const before = (prev.progress?.[uid] || []).length;
+          const after = (data.progress[uid] || []).length;
+          if (after > before) {
+            const member = data.members?.find((m) => m.userId === uid);
+            setActivityMsg(`${member?.displayName || uid} visited stop ${after}`);
+            setTimeout(() => setActivityMsg(''), 3000);
+          }
+        });
+      }
+      prev = data;
+    });
+    return () => unsub();
+  }, [groupId]);
+
+  // Load personal progress when not in group
+  useEffect(() => {
+    if (groupId) return;
     const auth = getAuth();
     const user = auth.currentUser;
     if (!user || !questId) return;
@@ -57,10 +98,19 @@ export default function QuestLivePage() {
         console.error('Failed to load progress', err);
       }
     })();
-  }, [quest]);
+  }, [quest, groupId]);
 
   const currentStopIndex = visitedIndices.length;
   const allVisited = visitedIndices.length >= (quest?.places?.length || 0);
+  const questComplete = allVisited || groupData?.completed;
+
+  useEffect(() => {
+    if (questComplete) {
+      setShowComplete(true);
+      const t = setTimeout(() => setShowComplete(false), 3000);
+      return () => clearTimeout(t);
+    }
+  }, [questComplete]);
 
 
   useEffect(() => {
@@ -91,10 +141,15 @@ export default function QuestLivePage() {
     const user = auth.currentUser;
     if (!user) return alert("You must be logged in!");
 
-    if (!questId) return;
+    if (!questId || questComplete) return;
     try {
-      const res = await trackVisit(user.uid, questId, visitedIndices.length);
-      setVisitedIndices(res.visitedIndices || []);
+      if (groupId) {
+        const res = await trackStopVisit(groupId, user.uid, visitedIndices.length);
+        setVisitedIndices(res.visitedStops || res.visitedIndices || []);
+      } else {
+        const res = await trackVisit(user.uid, questId, visitedIndices.length);
+        setVisitedIndices(res.visitedIndices || []);
+      }
     } catch (err) {
       console.error('Failed to track visit', err);
     }
@@ -108,6 +163,7 @@ export default function QuestLivePage() {
     setSaving(true);
     setCompleteMsg("");
     try {
+      const share = window.confirm('Share this quest publicly?');
       await completeQuest(user.uid, questId, {
         title: quest.title,
         city: quest.city,
@@ -118,7 +174,12 @@ export default function QuestLivePage() {
         imagePrompt: quest.imagePrompt,
         imageUrl: quest.imageUrl,
         visitedIndices,
+        public: share,
+        displayName: user.displayName,
       });
+      if (groupId) {
+        await completeGroupQuest(groupId, user.uid);
+      }
       setCompleteMsg("Quest Saved to Your Profile!");
       window.dispatchEvent(new Event("quest-saved"));
     } catch (err) {
@@ -130,12 +191,43 @@ export default function QuestLivePage() {
 
   };
 
+  const handleReport = async () => {
+    const reason = window.prompt('Reason for report?');
+    if (!reason) return;
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user) return alert('You must be logged in!');
+    try {
+      await reportQuest(user.uid, questId, reason, quest.city, quest.mood);
+      alert('Report submitted');
+    } catch (err) {
+      console.error('failed to report quest', err);
+    }
+  };
+
+  const handleLeave = async () => {
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user || !groupId) return;
+    try {
+      await leaveGroup(groupId, user.uid);
+      navigate('/home');
+    } catch (err) {
+      console.error('failed to leave group', err);
+    }
+  };
+
   if (!quest) {
     return <div className="p-6 text-center text-red-600">Quest data missing.</div>;
   }
 
   return (
     <div className="relative flex min-h-screen flex-col bg-[#f8fcf8] overflow-x-hidden font-jakarta">
+      {showComplete && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/80 text-3xl font-bold animate-bounce">
+          Quest Complete!
+        </div>
+      )}
       <div className="flex h-full flex-col">
         <header className="flex items-center justify-between border-b border-[#e7f3e7] px-10 py-3">
           <div className="flex items-center gap-4 text-[#0e1b0e]">
@@ -173,20 +265,50 @@ export default function QuestLivePage() {
 
         <main className="px-10 py-5 flex flex-col max-w-4xl mx-auto w-full">
           <div className="flex flex-wrap justify-between gap-3 p-4">
-            <div className="flex flex-col gap-3 min-w-72">
-              <p className="text-2xl font-bold text-[#0e1b0e]">
-                {quest?.title || "Your Quest"}
-              </p>
-              <p className="text-sm text-[#4e974e]">
-                {quest?.questText || "Embark on your adventure"}
-              </p>
+          <div className="flex flex-col gap-3 min-w-72">
+            <p className="text-2xl font-bold text-[#0e1b0e]">
+              {quest?.title || "Your Quest"}
+            </p>
+            <p className="text-sm text-[#4e974e]">
+              {quest?.questText || "Embark on your adventure"}
+            </p>
+            {groupId && (
+              <div className="text-xs text-blue-700 space-y-1">
+                <div className="flex items-center gap-2">
+                  <span className="break-all">Invite: {`${window.location.origin}/live?groupId=${groupId}`}</span>
+                  <button
+                    onClick={() => {
+                      navigator.clipboard.writeText(`${window.location.origin}/live?groupId=${groupId}`);
+                      setCopied(true);
+                      setTimeout(() => setCopied(false), 1500);
+                    }}
+                    className="px-2 py-0.5 rounded bg-blue-600 text-white"
+                  >
+                    {copied ? 'Copied!' : 'Copy'}
+                  </button>
+                </div>
+                {groupData && (
+                  <GroupMemberList members={groupData.members || []} progress={groupData.progress || {}} total={quest?.places?.length || 0} />
+                )}
+              </div>
+            )}
+          </div>
+            <div className="flex gap-2">
+              {groupId && (
+                <button
+                  onClick={handleLeave}
+                  className="h-8 px-4 rounded-full bg-red-500 text-sm text-white"
+                >
+                  Leave Group
+                </button>
+              )}
+              <button
+                onClick={() => window.location.assign('/home')}
+                className="h-8 px-4 rounded-full bg-[#e7f3e7] text-sm text-[#0e1b0e]"
+              >
+                Back to Home
+              </button>
             </div>
-            <button
-              onClick={() => window.location.assign('/home')}
-              className="h-8 px-4 rounded-full bg-[#e7f3e7] text-sm text-[#0e1b0e]"
-            >
-              Back to Home
-            </button>
           </div>
 
           <div className="p-4">
@@ -196,13 +318,16 @@ export default function QuestLivePage() {
                 {visitedIndices.length}/{quest?.places?.length}
               </p>
             </div>
-            <div className="w-full bg-[#d0e7d0] rounded">
-              <div
-                className="h-2 rounded bg-[#14b714]"
-                style={{ width: `${(visitedIndices.length / (quest?.places?.length || 1)) * 100}%` }}
-              />
-            </div>
+          <div className="w-full bg-[#d0e7d0] rounded">
+            <div
+              className="h-2 rounded bg-[#14b714]"
+              style={{ width: `${(visitedIndices.length / (quest?.places?.length || 1)) * 100}%` }}
+            />
           </div>
+        </div>
+        {activityMsg && (
+          <p className="text-xs text-center text-blue-700 mt-1">{activityMsg}</p>
+        )}
 
           <div className="px-4 py-3">
             <LiveQuestMap stops={stops} visitedIndex={currentStopIndex} userLocation={userLocation} />
@@ -215,18 +340,18 @@ export default function QuestLivePage() {
           <div className="flex px-4 py-3">
             <button
               onClick={handleMarkVisited}
-              disabled={allVisited}
+              disabled={questComplete}
               className={`flex-1 h-12 rounded-full text-base font-bold text-[#f8fcf8] ${
-                allVisited
+                questComplete
                   ? "bg-gray-400 cursor-not-allowed"
                   : "bg-[#14b714] hover:bg-[#0fa50f]"
               }`}
             >
-              {allVisited ? "Quest Complete!" : "Mark as Visited"}
+              {questComplete ? "Quest Complete!" : "Mark as Visited"}
             </button>
           </div>
 
-          {allVisited && (
+          {questComplete && (
             <div className="flex px-4 py-3">
               <button
                 onClick={handleComplete}
@@ -240,6 +365,11 @@ export default function QuestLivePage() {
           {completeMsg && (
             <p className="text-center text-green-700 mt-2">{completeMsg}</p>
           )}
+          <div className="px-4 py-2">
+            <button onClick={handleReport} className="text-xs text-red-600 underline">
+              Report Quest
+            </button>
+          </div>
         </main>
       </div>
     </div>

--- a/frontend/src/components/QuestPlusPage.jsx
+++ b/frontend/src/components/QuestPlusPage.jsx
@@ -1,11 +1,22 @@
 import React, { useState } from 'react';
+import { getAuth } from 'firebase/auth';
+import { createCheckoutSession } from '../lib/api';
 
 const QuestPlusPage = () => {
   const [loading, setLoading] = useState(false);
 
-  const handleCheckout = () => {
+  const handleCheckout = async () => {
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user) return alert('You must be logged in');
     setLoading(true);
-    window.location.href = 'https://buy.stripe.com/test_4gw4jA8AcdFr0Te8ww';
+    try {
+      const data = await createCheckoutSession(user.uid, user.email);
+      window.location.href = data.url;
+    } catch (err) {
+      console.error('Checkout failed', err);
+      setLoading(false);
+    }
   };
 
   return (

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -62,8 +62,10 @@ export async function uploadPostcard(userId, questId, imageUrl) {
   return resp.json();
 }
 
-export async function validatePremium(userId) {
-  const resp = await fetch(`${BASE_URL}/validate-premium/${userId}`);
+export async function validatePremium(userId, sessionId) {
+  const url = new URL(`${BASE_URL}/validate-premium/${userId}`);
+  if (sessionId) url.searchParams.set('session_id', sessionId);
+  const resp = await fetch(url.toString());
   if (!resp.ok) {
     throw new Error('Failed to validate premium');
   }
@@ -102,3 +104,131 @@ export async function trackVisit(userId, questId, placeIndex) {
   return resp.json();
 }
 
+
+export async function createGroupQuest(userId, questId, displayName) {
+  const resp = await fetch(`${BASE_URL}/create-group-quest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, questId, displayName })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to create group');
+  }
+  return resp.json();
+}
+
+export async function joinGroup(userId, groupId, displayName) {
+  const resp = await fetch(`${BASE_URL}/join-group`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, groupId, displayName })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to join group');
+  }
+  return resp.json();
+}
+
+export async function trackStopVisit(groupId, userId, placeIndex) {
+  const resp = await fetch(`${BASE_URL}/track-stop-visit`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ groupId, userId, placeIndex })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to track stop');
+  }
+  return resp.json();
+}
+
+export async function completeGroupQuest(groupId, userId) {
+  const resp = await fetch(`${BASE_URL}/complete-group-quest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ groupId, userId })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to complete group quest');
+  }
+  return resp.json();
+}
+
+export async function leaveGroup(groupId, userId) {
+  const resp = await fetch(`${BASE_URL}/leave-group`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ groupId, userId })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to leave group');
+  }
+  return resp.json();
+}
+
+export async function getActiveQuest(userId) {
+  const resp = await fetch(`${BASE_URL}/active-quest/${userId}`);
+  if (!resp.ok) {
+    return null;
+  }
+  return resp.json();
+}
+
+export async function getQuest(questId) {
+  const resp = await fetch(`${BASE_URL}/get-quest/${questId}`);
+  if (!resp.ok) {
+    throw new Error('Failed to fetch quest');
+  }
+  return resp.json();
+}
+
+export async function getCommunityQuests() {
+  const resp = await fetch(`${BASE_URL}/get-community-quests`);
+  if (!resp.ok) {
+    throw new Error('Failed to load community quests');
+  }
+  return resp.json();
+}
+
+export async function reportQuest(userId, questId, reason, city, mood) {
+  const resp = await fetch(`${BASE_URL}/report-quest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, questId, reason, city, mood })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to report quest');
+  }
+  return resp.json();
+}
+
+export async function getQuestReports() {
+  const resp = await fetch(`${BASE_URL}/get-quest-reports`);
+  if (!resp.ok) {
+    throw new Error('Failed to load reports');
+  }
+  return resp.json();
+}
+
+export async function toggleQuestVisibility(questId, userId, visible) {
+  const resp = await fetch(`${BASE_URL}/toggle-quest-visibility`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ questId, userId, visible })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to update visibility');
+  }
+  return resp.json();
+}
+
+export async function createCheckoutSession(userId, email) {
+  const resp = await fetch(`${BASE_URL}/create-checkout-session`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, email, baseUrl: window.location.origin })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to create checkout session');
+  }
+  return resp.json();
+}


### PR DESCRIPTION
## Summary
- support defensive checks for group quest activities
- auto resume only if quest and group are valid
- allow leaving group quests and add progress overlay
- show copy feedback and animated completion notice
- add community feed and quest reporting capabilities
- add admin dashboard and quest visibility toggling
- integrate Stripe checkout with mock fallback
- gate quest creation and history by Quest+ status
- polish header navigation with Quest+ link

## Testing
- `npm --prefix frontend run lint`
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6881177da2dc832198ba09841e0f1757