### PR TITLE
Add community quest interaction endpoints

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -347,6 +347,28 @@ async def complete_quest(payload: dict = Body(...)):
         print("Firestore REST error", resp.text)
         resp.raise_for_status()
 
+    if payload.get("public"):
+        feed_id = f"{quest_id}_{user_id}"
+        feed_doc = {
+            "city": payload.get("city"),
+            "mood": payload.get("mood"),
+            "displayName": payload.get("displayName"),
+            "imageUrl": payload.get("imageUrl"),
+            "questText": payload.get("questText"),
+            "completedAt": timestamp,
+            "userId": user_id,
+            "questId": quest_id,
+            "title": payload.get("title"),
+        }
+        feed_url = (
+            f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/community_quests/{feed_id}"
+        )
+        feed_body = {"fields": _encode_fields(feed_doc)}
+        fr = await asyncio.to_thread(rest_session.patch, feed_url, json=feed_body)
+        if fr.status_code != 200:
+            print("Firestore REST error", fr.text)
+            fr.raise_for_status()
+
     return {"status": "completed", "newXP": xp, "badges": badges}
 
 
@@ -549,6 +571,8 @@ async def get_user_quests(userId: str = Query(...)):
         if not doc:
             continue
         obj = _decode_document(doc)
+        if obj.get("visible") is False:
+            continue
         obj["id"] = doc["name"].split("/")[-1]
         results.append(obj)
     return {"quests": results}
@@ -666,12 +690,6 @@ async def reroll_quest(payload: dict = Body(...)):
     return await generate_quest(city=city, moods=moods, time_limit=time_limit, token=token)
 
 
-@app.get("/validate-premium/{user_id}")
-async def validate_premium(user_id: str):
-    """Mock premium validation."""
-    return {"premium": True}
-
-
 @app.post("/get-directions")
 async def get_directions(payload: dict = Body(...)):
     """Return mocked directions data for a list of places."""
@@ -698,4 +716,707 @@ async def get_directions(payload: dict = Body(...)):
         ],
         "totalTime": "22 mins",
     }
+
+
+@app.post("/create-group-quest")
+async def create_group_quest(payload: dict = Body(...)):
+    """Create a shared group quest and set user active state."""
+    user_id = payload.get("userId")
+    quest_id = payload.get("questId")
+    display_name = payload.get("displayName")
+    if not user_id or not quest_id:
+        return {"error": "userId and questId required"}
+
+    project_id = creds.project_id
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    active_resp = await asyncio.to_thread(rest_session.get, active_url)
+    if active_resp.status_code == 200:
+        active_fields = _decode_document(active_resp.json())
+        if active_fields.get("status") != "completed":
+            return {"error": "active quest already"}
+
+    group_id = hashlib.sha1(f"{user_id}-{quest_id}-{datetime.utcnow()}".encode()).hexdigest()[:8]
+
+    member_entry = {"userId": user_id, "displayName": display_name or user_id}
+    group_doc = {
+        "questId": quest_id,
+        "members": [member_entry],
+        "progress": {user_id: []},
+        "invitedBy": user_id,
+        "completed": False,
+        "createdAt": datetime.utcnow().isoformat(),
+    }
+    group_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/groups/{group_id}"
+    body = {"fields": _encode_fields(group_doc)}
+    resp = await asyncio.to_thread(rest_session.patch, group_url, json=body)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+
+    active_doc = {
+        "groupId": group_id,
+        "questId": quest_id,
+        "status": "active",
+        "visitedStops": [],
+        "startedAt": datetime.utcnow().isoformat(),
+    }
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    active_body = {"fields": _encode_fields(active_doc)}
+    await asyncio.to_thread(rest_session.patch, active_url, json=active_body)
+
+    return {"groupId": group_id}
+
+
+@app.post("/join-group")
+async def join_group(payload: dict = Body(...)):
+    """Add a user to an existing group quest."""
+    user_id = payload.get("userId")
+    group_id = payload.get("groupId")
+    display_name = payload.get("displayName")
+    if not user_id or not group_id:
+        return {"error": "userId and groupId required"}
+
+    project_id = creds.project_id
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    active_resp = await asyncio.to_thread(rest_session.get, active_url)
+    if active_resp.status_code == 200:
+        active_fields = _decode_document(active_resp.json())
+        if active_fields.get("status") != "completed" and active_fields.get("groupId") not in (None, group_id):
+            return {"error": "active quest already"}
+    group_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/groups/{group_id}"
+    resp = await asyncio.to_thread(rest_session.get, group_url)
+    if resp.status_code != 200:
+        return {"error": "Group not found"}
+    fields = _decode_document(resp.json())
+    if fields.get("completed"):
+        return {"error": "Group completed"}
+
+    members = fields.get("members", [])
+    if not any(m.get("userId") == user_id for m in members):
+        members.append({"userId": user_id, "displayName": display_name or user_id})
+    progress = fields.get("progress", {})
+    if user_id not in progress:
+        progress[user_id] = []
+
+    fields.update({"members": members, "progress": progress})
+    body = {"fields": _encode_fields(fields)}
+    await asyncio.to_thread(rest_session.patch, group_url, json=body)
+
+    active_doc = {
+        "groupId": group_id,
+        "questId": fields.get("questId"),
+        "status": "active",
+        "visitedStops": progress[user_id],
+        "startedAt": datetime.utcnow().isoformat(),
+    }
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    active_body = {"fields": _encode_fields(active_doc)}
+    await asyncio.to_thread(rest_session.patch, active_url, json=active_body)
+
+    return {"status": "joined", "questId": fields.get("questId")}
+
+
+@app.post("/track-stop-visit")
+async def track_stop_visit(payload: dict = Body(...)):
+    """Track a stop visit for a group quest."""
+    group_id = payload.get("groupId")
+    user_id = payload.get("userId")
+    place_index = payload.get("placeIndex")
+    if group_id is None or user_id is None or place_index is None:
+        return {"error": "groupId, userId and placeIndex required"}
+
+    project_id = creds.project_id
+    group_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/groups/{group_id}"
+    resp = await asyncio.to_thread(rest_session.get, group_url)
+    if resp.status_code != 200:
+        return {"error": "Group not found"}
+    fields = _decode_document(resp.json())
+    if fields.get("completed"):
+        return {"error": "Group completed"}
+    if not any(m.get("userId") == user_id for m in fields.get("members", [])):
+        return {"error": "Not a group member"}
+
+    progress = fields.get("progress", {})
+    user_progress = progress.get(user_id, [])
+    if place_index not in user_progress:
+        user_progress.append(place_index)
+        user_progress.sort()
+        progress[user_id] = user_progress
+        fields["progress"] = progress
+        body = {"fields": _encode_fields(fields)}
+        await asyncio.to_thread(rest_session.patch, group_url, json=body)
+
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    active_resp = await asyncio.to_thread(rest_session.get, active_url)
+    active_fields = {}
+    if active_resp.status_code == 200:
+        active_fields = _decode_document(active_resp.json())
+    active_fields.update({
+        "groupId": group_id,
+        "questId": fields.get("questId"),
+        "status": "active",
+        "visitedStops": user_progress,
+    })
+    active_body = {"fields": _encode_fields(active_fields)}
+    await asyncio.to_thread(rest_session.patch, active_url, json=active_body)
+
+    return {"visitedStops": user_progress}
+
+
+@app.post("/complete-group-quest")
+async def complete_group_quest(payload: dict = Body(...)):
+    """Mark a group quest as completed by a user."""
+    group_id = payload.get("groupId")
+    user_id = payload.get("userId")
+    if not group_id or not user_id:
+        return {"error": "groupId and userId required"}
+
+    project_id = creds.project_id
+    group_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/groups/{group_id}"
+    resp = await asyncio.to_thread(rest_session.get, group_url)
+    if resp.status_code != 200:
+        return {"error": "Group not found"}
+    fields = _decode_document(resp.json())
+    if fields.get("completed"):
+        return {"error": "Group already completed"}
+    if not any(m.get("userId") == user_id for m in fields.get("members", [])):
+        return {"error": "Not a group member"}
+    fields["completed"] = True
+    body = {"fields": _encode_fields(fields)}
+    await asyncio.to_thread(rest_session.patch, group_url, json=body)
+
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    active_fields = {
+        "groupId": group_id,
+        "questId": fields.get("questId"),
+        "status": "completed",
+    }
+    active_body = {"fields": _encode_fields(active_fields)}
+    await asyncio.to_thread(rest_session.patch, active_url, json=active_body)
+
+    return {"status": "completed"}
+
+
+@app.get("/active-quest/{user_id}")
+async def get_active_quest(user_id: str):
+    """Return the current active quest doc for the user."""
+    project_id = creds.project_id
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    resp = await asyncio.to_thread(rest_session.get, url)
+    if resp.status_code != 200:
+        return {}
+    active = _decode_document(resp.json())
+
+    quest_ok = True
+    if active.get("questId"):
+        qurl = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/quests/{active['questId']}"
+        qresp = await asyncio.to_thread(rest_session.get, qurl)
+        quest_ok = qresp.status_code == 200
+
+    group_ok = True
+    if active.get("groupId"):
+        gurl = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/groups/{active['groupId']}"
+        gresp = await asyncio.to_thread(rest_session.get, gurl)
+        if gresp.status_code != 200:
+            group_ok = False
+        else:
+            gdata = _decode_document(gresp.json())
+            group_ok = not gdata.get("completed")
+
+    if not quest_ok or not group_ok:
+        await asyncio.to_thread(rest_session.delete, url)
+        return {}
+
+    return active
+
+
+@app.post("/leave-group")
+async def leave_group(payload: dict = Body(...)):
+    """Remove a user from a group and clear their active quest."""
+    user_id = payload.get("userId")
+    group_id = payload.get("groupId")
+    if not user_id or not group_id:
+        return {"error": "userId and groupId required"}
+
+    project_id = creds.project_id
+    group_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/groups/{group_id}"
+    resp = await asyncio.to_thread(rest_session.get, group_url)
+    if resp.status_code == 200:
+        fields = _decode_document(resp.json())
+        members = [m for m in fields.get("members", []) if m.get("userId") != user_id]
+        progress = fields.get("progress", {})
+        progress.pop(user_id, None)
+        fields.update({"members": members, "progress": progress})
+        body = {"fields": _encode_fields(fields)}
+        await asyncio.to_thread(rest_session.patch, group_url, json=body)
+
+    active_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    await asyncio.to_thread(rest_session.delete, active_url)
+    return {"status": "left"}
+
+
+@app.post("/report-quest")
+async def report_quest(payload: dict = Body(...)):
+    """Receive a quest report and store in Firestore."""
+    user_id = payload.get("userId")
+    quest_id = payload.get("questId")
+    reason = payload.get("reason")
+    if not user_id or not quest_id or not reason:
+        return {"error": "userId, questId and reason required"}
+
+    project_id = creds.project_id
+    doc_id = f"{quest_id}_{user_id}"
+    report = {
+        "userId": user_id,
+        "questId": quest_id,
+        "reason": reason,
+        "city": payload.get("city"),
+        "mood": payload.get("mood"),
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/quest_reports/{doc_id}"
+    body = {"fields": _encode_fields(report)}
+    resp = await asyncio.to_thread(rest_session.patch, url, json=body)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+    return {"status": "reported"}
+
+
+@app.get("/get-quest-reports")
+async def get_quest_reports():
+    """Return recent quest reports for admin review."""
+    project_id = creds.project_id
+    url = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/quest_reports:runQuery"
+    )
+    query = {
+        "structuredQuery": {
+            "from": [{"collectionId": "quest_reports"}],
+            "orderBy": [{"field": {"fieldPath": "timestamp"}, "direction": "DESCENDING"}],
+            "limit": 20,
+        }
+    }
+    resp = await asyncio.to_thread(rest_session.post, url, json=query)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+    raw = resp.json()
+    results = []
+    for item in raw:
+        doc = item.get("document")
+        if not doc:
+            continue
+        obj = _decode_document(doc)
+        obj["id"] = doc["name"].split("/")[-1]
+        results.append(obj)
+    return {"reports": results}
+
+
+@app.post("/toggle-quest-visibility")
+async def toggle_quest_visibility(payload: dict = Body(...)):
+    """Hide or show a community quest."""
+    quest_id = payload.get("questId")
+    user_id = payload.get("userId")
+    visible = payload.get("visible", True)
+    if not quest_id or not user_id:
+        return {"error": "questId and userId required"}
+
+    project_id = creds.project_id
+    doc_id = f"{quest_id}_{user_id}"
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/community_quests/{doc_id}"
+    body = {"fields": _encode_fields({"visible": visible})}
+    resp = await asyncio.to_thread(rest_session.patch, url, json=body)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+    return {"status": "updated"}
+
+
+@app.get("/get-community-quests")
+async def get_community_quests():
+    """Return recently completed public quests."""
+    project_id = creds.project_id
+    url = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/community_quests:runQuery"
+    )
+    query = {
+        "structuredQuery": {
+            "from": [{"collectionId": "community_quests"}],
+            "orderBy": [{"field": {"fieldPath": "completedAt"}, "direction": "DESCENDING"}],
+            "limit": 20,
+        }
+    }
+    resp = await asyncio.to_thread(rest_session.post, url, json=query)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+    raw = resp.json()
+    results = []
+    for item in raw:
+        doc = item.get("document")
+        if not doc:
+            continue
+        obj = _decode_document(doc)
+        if obj.get("visible") is False:
+            continue
+        obj["id"] = doc["name"].split("/")[-1]
+        results.append(obj)
+    return {"quests": results}
+
+@app.post("/create-checkout-session")
+async def create_checkout_session(payload: dict = Body(...)):
+    """Return a Stripe Checkout URL or mock URL."""
+    user_id = payload.get("userId")
+    email = payload.get("email")
+    if not user_id or not email:
+        return {"error": "userId and email required"}
+
+    base_url = payload.get("baseUrl", "https://example.com")
+    success = f"{base_url}/payment-success?userId={user_id}&session_id={{CHECKOUT_SESSION_ID}}"
+    cancel = f"{base_url}/payment-failed"
+    stripe_key = os.getenv("STRIPE_SECRET_KEY")
+    if stripe_key:
+        try:
+            import stripe
+            stripe.api_key = stripe_key
+            session = await asyncio.to_thread(
+                stripe.checkout.Session.create,
+                payment_method_types=["card"],
+                mode="payment",
+                line_items=[{"price": os.getenv("STRIPE_PRICE_ID", "price_123"), "quantity": 1}],
+                customer_email=email,
+                success_url=success,
+                cancel_url=cancel,
+            )
+            return {"url": session.url}
+        except Exception as e:
+            print("Stripe error", e)
+            return {"error": "stripe failed"}
+    # Fallback mock URL
+    return {"url": success.replace("{CHECKOUT_SESSION_ID}", "mock")}
+
+
+@app.get("/validate-premium/{user_id}")
+async def validate_premium(user_id: str, session_id: str | None = Query(None)):
+    """Check premium flag and optionally verify checkout session."""
+    project_id = creds.project_id
+    user_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/users/{user_id}"
+    resp = await asyncio.to_thread(rest_session.get, user_url)
+    fields = {}
+    if resp.status_code == 200:
+        fields = _decode_document(resp.json())
+    premium = fields.get("premium") is True
+
+    if not premium and session_id:
+        stripe_key = os.getenv("STRIPE_SECRET_KEY")
+        if stripe_key and session_id != "mock":
+            try:
+                import stripe
+                stripe.api_key = stripe_key
+                sess = await asyncio.to_thread(stripe.checkout.Session.retrieve, session_id)
+                premium = sess.get("payment_status") == "paid"
+            except Exception as e:
+                print("Stripe verify error", e)
+                premium = False
+        elif session_id == "mock":
+            premium = True
+        if premium:
+            fields["premium"] = True
+            body = {"fields": _encode_fields(fields)}
+            await asyncio.to_thread(rest_session.patch, user_url, json=body)
+
+    return {"premium": premium}
+
+
+@app.post("/update-active-quest")
+async def update_active_quest(payload: dict = Body(...)):
+    """Patch the user's active quest document with extra data."""
+    user_id = payload.get("userId")
+    data = payload.get("data")
+    if not user_id or not isinstance(data, dict):
+        return {"error": "userId and data required"}
+
+    project_id = creds.project_id
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_active_quest/{user_id}"
+    resp = await asyncio.to_thread(rest_session.get, url)
+    fields = {}
+    if resp.status_code == 200:
+        fields = _decode_document(resp.json())
+    fields.update(data)
+    body = {"fields": _encode_fields(fields)}
+    resp = await asyncio.to_thread(rest_session.patch, url, json=body)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+    return {"status": "updated"}
+
+
+@app.post("/create-custom-quest")
+async def create_custom_quest(payload: dict = Body(...)):
+    """Store a manually crafted quest."""
+    user_id = payload.get("user_id")
+    places = payload.get("places", [])
+    if not user_id or len(places) < 2:
+        return {"error": "user_id and at least 2 places required"}
+
+    project_id = creds.project_id
+    quest_id = hashlib.sha1(
+        f"{user_id}-{datetime.utcnow()}-{payload.get('title','custom')}".encode()
+    ).hexdigest()[:12]
+
+    status = payload.get("status", "draft")
+    public = payload.get("public", False)
+
+    quest_doc = {
+        "title": payload.get("title") or "Custom Quest",
+        "moodTags": payload.get("mood_tags", []),
+        "places": places,
+        "timeLimit": payload.get("time_limit", 60),
+        "customPrompt": payload.get("custom_prompt") or "",
+        "createdBy": user_id,
+        "createdAt": datetime.utcnow().isoformat(),
+        "type": "custom",
+        "status": status,
+        "public": public,
+        "likesCount": 0,
+        "viewsCount": 0,
+        "replaysCount": 0,
+    }
+    if status == "published" or public:
+        quest_doc["publishedAt"] = datetime.utcnow().isoformat()
+
+    body = {"fields": _encode_fields(quest_doc)}
+
+    user_url = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_quests/{user_id}/{quest_id}"
+    )
+    resp = await asyncio.to_thread(rest_session.patch, user_url, json=body)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+
+    global_url = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/custom_quests/{quest_id}"
+    )
+    await asyncio.to_thread(rest_session.patch, global_url, json=body)
+
+    group_id = payload.get("group_id")
+    if group_id:
+        g_url = (
+            f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/group_quests/{group_id}/{quest_id}"
+        )
+        await asyncio.to_thread(rest_session.patch, g_url, json=body)
+
+    return {"questId": quest_id, "quest": quest_doc}
+
+
+@app.get("/get-custom-quest/{quest_id}")
+async def get_custom_quest(quest_id: str):
+    """Fetch a custom quest by ID."""
+    project_id = creds.project_id
+    url = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/custom_quests/{quest_id}"
+    )
+    resp = await asyncio.to_thread(rest_session.get, url)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+    return resp.json()
+
+
+@app.post("/publish-custom-quest")
+async def publish_custom_quest(payload: dict = Body(...)):
+    """Mark a custom quest as public and published."""
+    user_id = payload.get("user_id")
+    quest_id = payload.get("quest_id")
+    if not user_id or not quest_id:
+        return {"error": "user_id and quest_id required"}
+
+    project_id = creds.project_id
+    patch_fields = {
+        "status": "published",
+        "public": True,
+        "publishedAt": datetime.utcnow().isoformat(),
+    }
+    body = {"fields": _encode_fields(patch_fields)}
+
+    user_url = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/user_quests/{user_id}/{quest_id}"
+    )
+    global_url = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/custom_quests/{quest_id}"
+    )
+    for url in (user_url, global_url):
+        resp = await asyncio.to_thread(rest_session.patch, url, json=body)
+        if resp.status_code != 200:
+            print("Firestore REST error", resp.text)
+            resp.raise_for_status()
+
+    return {"status": "published"}
+
+
+@app.post("/like-quest")
+async def like_quest(payload: dict = Body(...)):
+    """Record a quest like and increment counter."""
+    user_id = payload.get("user_id")
+    quest_id = payload.get("quest_id")
+    if not user_id or not quest_id:
+        return {"error": "user_id and quest_id required"}
+
+    project_id = creds.project_id
+    like_url = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/quest_likes/{quest_id}/{user_id}"
+    )
+    body = {"fields": _encode_fields({"timestamp": datetime.utcnow().isoformat()})}
+    resp = await asyncio.to_thread(rest_session.patch, like_url, json=body)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+
+    quest_url = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/custom_quests/{quest_id}"
+    )
+    qresp = await asyncio.to_thread(rest_session.get, quest_url)
+    if qresp.status_code == 200:
+        data = _decode_document(qresp.json())
+        count = data.get("likesCount", 0) + 1
+        patch = {"fields": _encode_fields({"likesCount": count})}
+        await asyncio.to_thread(rest_session.patch, quest_url, json=patch)
+
+    return {"status": "liked"}
+
+
+@app.post("/view-quest")
+async def view_quest(payload: dict = Body(...)):
+    """Record a unique quest view."""
+    user_id = payload.get("user_id")
+    quest_id = payload.get("quest_id")
+    if not user_id or not quest_id:
+        return {"error": "user_id and quest_id required"}
+
+    project_id = creds.project_id
+    view_doc = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/quest_views/{quest_id}/{user_id}"
+    )
+    resp = await asyncio.to_thread(rest_session.get, view_doc)
+    if resp.status_code == 404:
+        body = {"fields": _encode_fields({"timestamp": datetime.utcnow().isoformat()})}
+        await asyncio.to_thread(rest_session.patch, view_doc, json=body)
+
+        quest_url = (
+            f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/custom_quests/{quest_id}"
+        )
+        qresp = await asyncio.to_thread(rest_session.get, quest_url)
+        if qresp.status_code == 200:
+            data = _decode_document(qresp.json())
+            count = data.get("viewsCount", 0) + 1
+            patch = {"fields": _encode_fields({"viewsCount": count})}
+            await asyncio.to_thread(rest_session.patch, quest_url, json=patch)
+
+    return {"status": "viewed"}
+
+
+@app.post("/replay-quest")
+async def replay_quest(payload: dict = Body(...)):
+    """Increment replay counter for a quest."""
+    quest_id = payload.get("quest_id")
+    if not quest_id:
+        return {"error": "quest_id required"}
+
+    project_id = creds.project_id
+    quest_url = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/custom_quests/{quest_id}"
+    )
+    qresp = await asyncio.to_thread(rest_session.get, quest_url)
+    if qresp.status_code == 200:
+        data = _decode_document(qresp.json())
+        count = data.get("replaysCount", 0) + 1
+        patch = {"fields": _encode_fields({"replaysCount": count})}
+        await asyncio.to_thread(rest_session.patch, quest_url, json=patch)
+
+    return {"status": "replayed"}
+
+
+@app.post("/create-community-group")
+async def create_community_group(payload: dict = Body(...)):
+    """Create a new community group."""
+    name = payload.get("name")
+    creator = payload.get("creator")
+    if not name or not creator:
+        return {"error": "name and creator required"}
+
+    project_id = creds.project_id
+    group_id = hashlib.sha1(f"{name}-{datetime.utcnow()}".encode()).hexdigest()[:10]
+    doc = {
+        "name": name,
+        "creator": creator,
+        "description": payload.get("description", ""),
+        "tags": payload.get("tags", []),
+        "imageUrl": payload.get("imageUrl", ""),
+        "members": [creator],
+        "linked_quests": [],
+        "createdAt": datetime.utcnow().isoformat(),
+    }
+    url = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/community_groups/{group_id}"
+    )
+    body = {"fields": _encode_fields(doc)}
+    resp = await asyncio.to_thread(rest_session.patch, url, json=body)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+    return {"groupId": group_id}
+
+
+@app.post("/join-community-group")
+async def join_community_group(payload: dict = Body(...)):
+    group_id = payload.get("group_id")
+    user_id = payload.get("user_id")
+    if not group_id or not user_id:
+        return {"error": "group_id and user_id required"}
+
+    project_id = creds.project_id
+    url = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/community_groups/{group_id}"
+    )
+    resp = await asyncio.to_thread(rest_session.get, url)
+    if resp.status_code != 200:
+        return {"error": "group not found"}
+    data = _decode_document(resp.json())
+    members = data.get("members", [])
+    if user_id not in members:
+        members.append(user_id)
+        data["members"] = members
+        body = {"fields": _encode_fields(data)}
+        await asyncio.to_thread(rest_session.patch, url, json=body)
+    return {"status": "joined"}
+
+
+@app.post("/link-quest-to-group")
+async def link_quest_to_group(payload: dict = Body(...)):
+    group_id = payload.get("group_id")
+    quest_id = payload.get("quest_id")
+    upcoming = payload.get("upcoming", False)
+    if not group_id or not quest_id:
+        return {"error": "group_id and quest_id required"}
+
+    project_id = creds.project_id
+    url = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/community_groups/{group_id}"
+    )
+    resp = await asyncio.to_thread(rest_session.get, url)
+    if resp.status_code != 200:
+        return {"error": "group not found"}
+    data = _decode_document(resp.json())
+    linked = data.get("linked_quests", [])
+    if quest_id not in linked:
+        linked.append(quest_id)
+    if upcoming:
+        data["upcoming_quest"] = quest_id
+    data["linked_quests"] = linked
+    body = {"fields": _encode_fields(data)}
+    await asyncio.to_thread(rest_session.patch, url, json=body)
+    return {"status": "linked"}
+
 

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,5 +1,10 @@
 // src/App.jsx
-import { Routes, Route } from "react-router-dom";
+import { Routes, Route, useNavigate, useLocation } from "react-router-dom";
+import { useEffect } from "react";
+import { onAuthStateChanged, getAuth } from "firebase/auth";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "./firebase";
+import { getActiveQuest, getQuest, leaveGroup } from "./lib/api";
 import LandingPage from "./components/LandingPage";
 import QuestHome from "./components/QuestHome";
 import QuestDetails from "./components/QuestDetails";
@@ -11,9 +16,41 @@ import QuestLivePage from "./components/QuestLivePage";
 import QuestPlusPage from "./components/QuestPlusPage";
 import PaymentSuccess from "./components/PaymentSuccess";
 import PaymentFailed from "./components/PaymentFailed";
+import CommunityFeed from "./components/CommunityFeed";
+import AdminDashboard from "./components/AdminDashboard";
+import CustomQuestBuilder from "./components/CustomQuestBuilder";
+import PublicQuestPage from "./components/PublicQuestPage";
 
 
 function App() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  useEffect(() => {
+    const auth = getAuth();
+    const unsub = onAuthStateChanged(auth, async (user) => {
+      if (!user) return;
+      try {
+        const data = await getActiveQuest(user.uid);
+        if (data && data.questId && data.status !== 'completed') {
+          const quest = await getQuest(data.questId).catch(() => null);
+          let groupOk = true;
+          if (data.groupId) {
+            const snap = await getDoc(doc(db, 'groups', data.groupId));
+            groupOk = snap.exists() && !snap.data().completed;
+          }
+          if (quest && groupOk && location.pathname !== '/live') {
+            navigate('/live', { state: { quest, questId: data.questId, groupId: data.groupId } });
+          } else if (!quest || !groupOk) {
+            if (data.groupId) await leaveGroup(data.groupId, user.uid);
+          }
+        }
+      } catch (err) {
+        console.error('resume failed', err);
+      }
+    });
+    return () => unsub();
+  }, [location.pathname, navigate]);
+
   return (
     <>
       <Header />
@@ -25,7 +62,11 @@ function App() {
         <Route path="/history" element={<QuestHistory />} />
         <Route path="/profile" element={<Profile />} />
         <Route path="/live" element={<QuestLivePage />} />
+        <Route path="/community" element={<CommunityFeed />} />
+        <Route path="/admin" element={<AdminDashboard />} />
         <Route path="/quest-plus" element={<QuestPlusPage />} />
+        <Route path="/custom" element={<CustomQuestBuilder />} />
+        <Route path="/q/:questId" element={<PublicQuestPage />} />
         <Route path="/payment-success" element={<PaymentSuccess />} />
         <Route path="/payment-failed" element={<PaymentFailed />} />
       </Routes>

--- a/frontend/src/components/AdminDashboard.jsx
+++ b/frontend/src/components/AdminDashboard.jsx
@@ -1,0 +1,53 @@
+import React, { useEffect, useState } from 'react';
+import { getQuestReports, toggleQuestVisibility } from '../lib/api';
+
+export default function AdminDashboard() {
+  const [reports, setReports] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await getQuestReports();
+        setReports(data.reports || []);
+      } catch (err) {
+        console.error('Failed to load reports', err);
+        setError('Failed to load reports');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const handleHide = async (r) => {
+    if (!window.confirm('Hide this quest from community feed?')) return;
+    try {
+      await toggleQuestVisibility(r.questId, r.userId, false);
+      alert('Quest hidden');
+    } catch (err) {
+      console.error('Failed to update visibility', err);
+    }
+  };
+
+  if (loading) return <div className="p-6">Loading...</div>;
+  if (error) return <div className="p-6 text-red-600">{error}</div>;
+
+  return (
+    <div className="min-h-screen bg-[#f8fcf8] px-6 py-8 text-[#0e1b0e] font-sans">
+      <h1 className="text-2xl font-bold mb-6">Admin Dashboard</h1>
+      <div className="space-y-4">
+        {reports.map((r) => (
+          <div key={r.id} className="flex justify-between bg-white p-4 rounded-lg shadow">
+            <div className="text-sm">
+              <p className="font-semibold">{r.city} - {r.mood}</p>
+              <p className="text-xs text-gray-600">By {r.userId}</p>
+              <p className="text-xs">Reason: {r.reason}</p>
+            </div>
+            <button onClick={() => handleHide(r)} className="h-8 px-3 rounded bg-red-500 text-white text-xs">Hide Quest</button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/CommunityFeed.jsx
+++ b/frontend/src/components/CommunityFeed.jsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import { getCommunityQuests, reportQuest } from '../lib/api';
+import { getAuth } from 'firebase/auth';
+
+export default function CommunityFeed() {
+  const [quests, setQuests] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await getCommunityQuests();
+        setQuests(data.quests || []);
+      } catch (err) {
+        console.error('Failed to load feed', err);
+        setError('Failed to load feed');
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  const handleReport = async (quest) => {
+    const reason = window.prompt('Reason for report?');
+    if (!reason) return;
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user) return alert('You must be logged in');
+    try {
+      await reportQuest(user.uid, quest.questId, reason, quest.city, quest.mood);
+      alert('Report submitted');
+    } catch (err) {
+      console.error('Failed to report quest', err);
+      alert('Failed to report quest');
+    }
+  };
+
+  if (loading) return <div className="p-6">Loading...</div>;
+  if (error) return <div className="p-6 text-red-600">{error}</div>;
+  if (quests.length === 0) return <div className="p-6">No public quests yet.</div>;
+
+  return (
+    <div className="min-h-screen bg-[#f8fcf8] px-6 py-8 text-[#0e1b0e] font-sans">
+      <h1 className="text-2xl font-bold mb-6">Community Feed</h1>
+      <div className="space-y-4">
+        {quests.map((q) => (
+          <div key={q.id} className="flex gap-4 bg-white p-4 rounded-lg shadow">
+            <img src={q.imageUrl || 'https://placehold.co/200'} alt="" className="w-32 h-20 object-cover rounded" />
+            <div className="flex-1 text-sm">
+              <h2 className="font-semibold">{q.title || 'Quest'}</h2>
+              <p className="text-gray-600">{q.city} - {q.mood}</p>
+              <p className="text-gray-500 text-xs">{new Date(q.completedAt).toLocaleString()}</p>
+              {q.displayName && <p className="text-xs">By {q.displayName}</p>}
+              <button onClick={() => handleReport(q)} className="text-red-500 underline text-xs mt-1">Report</button>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/CustomQuestBuilder.jsx
+++ b/frontend/src/components/CustomQuestBuilder.jsx
@@ -1,0 +1,309 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getAuth } from 'firebase/auth';
+import { createCustomQuest, createGroupQuest, validatePremium, publishCustomQuest } from '../lib/api';
+
+const moodOptions = [
+  'romantic',
+  'spooky',
+  'cozy',
+  'outdoorsy',
+  'historic',
+  'quirky',
+];
+
+const templates = [
+  { title: 'Romantic Stroll', moods: ['romantic'], prompt: 'A dreamy walk for two.' },
+  { title: 'Bar Crawl', moods: ['quirky'], prompt: 'A hopping night on the town.' },
+  { title: 'Cozy Coffee Walk', moods: ['cozy'], prompt: 'Sip and stroll to the best cafes.' },
+  { title: 'First Date Adventure', moods: ['romantic', 'outdoorsy'], prompt: 'Break the ice with fun mini challenges.' },
+  { title: 'Funky Vintage Hunt', moods: ['quirky'], prompt: 'Search for the coolest retro finds.' },
+];
+
+export default function CustomQuestBuilder() {
+  const [user, setUser] = useState(null);
+  const [premium, setPremium] = useState(false);
+  const [title, setTitle] = useState('');
+  const [moods, setMoods] = useState([]);
+  const [timeLimit, setTimeLimit] = useState(60);
+  const [prompt, setPrompt] = useState('');
+  const [locations, setLocations] = useState([
+    { name: '', placeId: '', lat: null, lng: null, duration: 10 },
+    { name: '', placeId: '', lat: null, lng: null, duration: 10 },
+  ]);
+  const [publishLink, setPublishLink] = useState('');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const auth = getAuth();
+    const u = auth.currentUser;
+    setUser(u);
+    if (!u) return;
+    validatePremium(u.uid)
+      .then((r) => setPremium(!!r.premium))
+      .catch(() => setPremium(false));
+  }, []);
+
+  useEffect(() => {
+    if (!window.google || !window.google.maps || !window.google.maps.places) return;
+    locations.forEach((_, idx) => {
+      const input = document.getElementById(`loc-${idx}`);
+      if (!input || input._ac) return;
+      const ac = new window.google.maps.places.Autocomplete(input);
+      input._ac = ac;
+      ac.addListener('place_changed', () => {
+        const p = ac.getPlace();
+        if (!p.geometry) return;
+        const { lat, lng } = p.geometry.location.toJSON();
+        const updated = [...locations];
+        updated[idx] = {
+          ...updated[idx],
+          name: p.name,
+          placeId: p.place_id,
+          lat,
+          lng,
+        };
+        setLocations(updated);
+      });
+    });
+  }, [locations]);
+
+  const toggleMood = (m) => {
+    setMoods(moods.includes(m) ? moods.filter((x) => x !== m) : [...moods, m]);
+  };
+
+  const addLocation = () => {
+    if (locations.length >= 5) return;
+    setLocations([...locations, { name: '', placeId: '', lat: null, lng: null, duration: 10 }]);
+  };
+
+  const removeLocation = (i) => {
+    if (locations.length <= 2) return;
+    setLocations(locations.filter((_, idx) => idx !== i));
+  };
+
+  const handleStart = async () => {
+    if (!user) return alert('Login required');
+    if (!premium) return navigate('/quest-plus');
+    if (locations.some((l) => !l.placeId)) return alert('Select valid locations');
+    try {
+      const res = await createCustomQuest({
+        user_id: user.uid,
+        title,
+        mood_tags: moods,
+        places: locations.map((l) => ({
+          name: l.name,
+          place_id: l.placeId,
+          lat: l.lat,
+          lng: l.lng,
+          duration_minutes: l.duration,
+        })),
+        time_limit: timeLimit,
+        custom_prompt: prompt,
+        status: 'draft',
+      });
+      const { questId, quest } = res;
+      const group = await createGroupQuest(user.uid, questId, user.displayName);
+      navigate('/live', { state: { quest, questId, groupId: group.groupId, timeLimit } });
+    } catch (err) {
+      console.error('custom quest failed', err);
+      alert('Failed to start custom quest');
+    }
+  };
+
+  const handleSaveDraft = async () => {
+    if (!user) return alert('Login required');
+    try {
+      await createCustomQuest({
+        user_id: user.uid,
+        title,
+        mood_tags: moods,
+        places: locations.map((l) => ({
+          name: l.name,
+          place_id: l.placeId,
+          lat: l.lat,
+          lng: l.lng,
+          duration_minutes: l.duration,
+        })),
+        time_limit: timeLimit,
+        custom_prompt: prompt,
+        status: 'draft',
+      });
+      alert('Draft saved!');
+    } catch (err) {
+      console.error('save draft failed', err);
+    }
+  };
+
+  const handlePublish = async () => {
+    if (!user) return alert('Login required');
+    if (!premium) return navigate('/quest-plus');
+    try {
+      const res = await createCustomQuest({
+        user_id: user.uid,
+        title,
+        mood_tags: moods,
+        places: locations.map((l) => ({
+          name: l.name,
+          place_id: l.placeId,
+          lat: l.lat,
+          lng: l.lng,
+          duration_minutes: l.duration,
+        })),
+        time_limit: timeLimit,
+        custom_prompt: prompt,
+        status: 'draft',
+      });
+      await publishCustomQuest(user.uid, res.questId);
+      setPublishLink(`${window.location.origin}/q/${res.questId}`);
+    } catch (err) {
+      console.error('publish failed', err);
+      alert('Failed to publish quest');
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f8fcf8] px-6 py-8 text-[#0e1b0e] font-sans">
+      <h1 className="text-2xl font-bold mb-6 text-center">Build a Custom Quest</h1>
+
+      <div className="space-y-4 max-w-xl mx-auto">
+        <select
+          className="w-full border p-2 rounded"
+          onChange={(e) => {
+            const t = templates[e.target.value];
+            if (t) {
+              setTitle(t.title);
+              setMoods(t.moods);
+              setPrompt(t.prompt);
+            }
+          }}
+        >
+          <option value="">Load Template...</option>
+          {templates.map((t, idx) => (
+            <option key={idx} value={idx}>{t.title}</option>
+          ))}
+        </select>
+        <input
+          type="text"
+          placeholder="Quest Title"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          className="w-full border p-2 rounded"
+        />
+
+        <div className="flex flex-wrap gap-2">
+          {moodOptions.map((m) => (
+            <button
+              key={m}
+              onClick={() => toggleMood(m)}
+              className={`px-3 py-1 rounded-full text-sm border ${
+                moods.includes(m) ? 'bg-green-600 text-white' : 'bg-white text-gray-700'
+              }`}
+            >
+              {m}
+            </button>
+          ))}
+        </div>
+
+        <label className="block">Time Limit: {timeLimit} mins</label>
+        <input
+          type="range"
+          min="30"
+          max="240"
+          step="30"
+          value={timeLimit}
+          onChange={(e) => setTimeLimit(parseInt(e.target.value, 10))}
+          className="w-full"
+        />
+
+        {locations.map((loc, idx) => (
+          <div key={idx} className="flex items-center gap-2">
+            <input
+              id={`loc-${idx}`}
+              type="text"
+              placeholder={`Location ${idx + 1}`}
+              className="flex-1 border p-2 rounded"
+            />
+            <select
+              value={loc.duration}
+              onChange={(e) => {
+                const updated = [...locations];
+                updated[idx].duration = parseInt(e.target.value, 10);
+                setLocations(updated);
+              }}
+              className="border p-2 rounded"
+            >
+              {[10, 20, 30, 45].map((d) => (
+                <option key={d} value={d}>
+                  {d} min
+                </option>
+              ))}
+            </select>
+            {locations.length > 2 && (
+              <button onClick={() => removeLocation(idx)} className="text-red-600 text-sm">X</button>
+            )}
+          </div>
+        ))}
+        {locations.length < 5 && (
+          <button onClick={addLocation} className="text-sm underline">
+            + Add Stop
+          </button>
+        )}
+
+        <textarea
+          value={prompt}
+          onChange={(e) => setPrompt(e.target.value)}
+          placeholder="Optional custom prompt or story..."
+          className="w-full border p-2 rounded h-24"
+        />
+
+        <button
+          onClick={handleStart}
+          disabled={!premium}
+          className={`w-full py-2 rounded-lg text-white ${
+            premium ? 'bg-blue-600 hover:bg-blue-700' : 'bg-gray-400 cursor-not-allowed'
+          }`}
+        >
+          Start Quest
+        </button>
+        <div className="flex gap-2">
+          <button
+            onClick={handleSaveDraft}
+            className="flex-1 py-2 rounded-lg border"
+          >
+            Save as Draft
+          </button>
+          <button
+            onClick={handlePublish}
+            disabled={!premium}
+            className={`flex-1 py-2 rounded-lg text-white ${
+              premium ? 'bg-green-600 hover:bg-green-700' : 'bg-gray-400 cursor-not-allowed'
+            }`}
+          >
+            Publish Quest
+          </button>
+        </div>
+        {publishLink && (
+          <div className="text-center text-sm">
+            Share Link:{' '}
+            <button
+              onClick={() => navigator.clipboard.writeText(publishLink)}
+              className="text-blue-600 underline"
+            >
+              {publishLink}
+            </button>
+          </div>
+        )}
+        {!premium && (
+          <p className="text-center text-sm">
+            Custom quests are a Quest+ feature.{' '}
+            <a href="/quest-plus" className="text-blue-600 underline">
+              Upgrade to Quest+
+            </a>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/frontend/src/components/GroupMemberList.jsx
+++ b/frontend/src/components/GroupMemberList.jsx
@@ -1,0 +1,17 @@
+import React from 'react';
+
+export default function GroupMemberList({ members = [], progress = {}, total = 0 }) {
+  return (
+    <ul className="text-sm space-y-1">
+      {members.map((m) => {
+        const count = (progress[m.userId] || []).length;
+        return (
+          <li key={m.userId} className="flex justify-between">
+            <span>{m.displayName || m.userId}</span>
+            <span>{count}/{total}</span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -1,9 +1,20 @@
 // src/components/Header.jsx
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
+import { getAuth, onAuthStateChanged } from "firebase/auth";
 
 const Header = () => {
   const { pathname } = useLocation();
+  const [isAdmin, setIsAdmin] = useState(false);
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const auth = getAuth();
+    return onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      setIsAdmin(u?.email === 'admin@roamio.app');
+    });
+  }, []);
 
   const linkClass = (path) =>
     `text-sm font-medium transition px-2 py-1 rounded ${
@@ -18,7 +29,17 @@ const Header = () => {
       <nav className="flex gap-4">
         <Link to="/home" className={linkClass("/home")}>Home</Link>
         <Link to="/history" className={linkClass("/history")}>History</Link>
-        <Link to="/profile" className={linkClass("/profile")}>Profile</Link>
+        <Link to="/community" className={linkClass("/community")}>Community</Link>
+        {user && (
+          <Link to="/custom" className={linkClass("/custom")}>➕ Custom Quest</Link>
+        )}
+        <Link to="/quest-plus" className={linkClass("/quest-plus")}>Quest+</Link>
+        {isAdmin && (
+          <Link to="/admin" className={linkClass("/admin")}>Admin</Link>
+        )}
+        {user && (
+          <Link to="/profile" className={linkClass("/profile")}>Profile</Link>
+        )}
       </nav>
     </header>
   );

--- a/frontend/src/components/LandingPage.jsx
+++ b/frontend/src/components/LandingPage.jsx
@@ -1,38 +1,53 @@
 // src/components/LandingPage.jsx
 import React from "react";
+import { signInWithPopup } from "firebase/auth";
+import { auth, provider } from "../firebase";
+import { useNavigate } from "react-router-dom";
 
-const LandingPage = ({ onStart }) => {
+const LandingPage = () => {
+  const navigate = useNavigate();
+
+  const handleLogin = async () => {
+    try {
+      await signInWithPopup(auth, provider);
+      navigate('/home');
+    } catch (err) {
+      console.error('login failed', err);
+    }
+  };
+
+  const demoQuest = () => {
+    navigate('/home');
+  };
+
   return (
-    <div className="flex min-h-screen items-center justify-center bg-[#f8fcfa] font-lexend overflow-x-hidden border-4 border-red-500">
-      <div className="w-full max-w-[960px] px-4 sm:px-6 md:px-10 border-4 border-red-400">
-        <div
-          className="min-h-[480px] flex flex-col gap-6 md:gap-8 bg-cover bg-center bg-no-repeat rounded-xl items-center justify-center p-6 md:p-10 border-4 border-red-300"
-          style={{
-            backgroundImage:
-              "linear-gradient(rgba(0, 0, 0, 0.1), rgba(0, 0, 0, 0.4)), url('https://lh3.googleusercontent.com/aida-public/AB6AXuBapA3FBg2w0FuvOO3ctZdu7WmzhhL_Wqu-eNicwiZuP89FCehxE0KMT6vSTp5WOpdGGHdf6zYopsdoLFMPqmNq4tpZ0PTCl6NtIZLfAoZX8sJPSbPUstTIPfqbdCwTxfMKyywdLMc5Ew10ksBohPf56UTOwYe_N9GQE-JpaMjgNu2YFBNlmbol-XU15E0DDUGhxryNexUG_Osz1QDBe-y03Ot1WBWv2b8Jea3wGQ2M9JmpzMSqPSd7vSGSxg7tub9rXGg92EsMFNw')",
-          }}
-        >
-          <div className="flex flex-col gap-2 text-center border-4 border-red-200 p-2">
-            <h1 className="text-white text-4xl sm:text-5xl font-black leading-tight tracking-tight border border-white p-1">
-              Quest Generator: Unearth Your World
-            </h1>
-            <h2 className="text-white text-sm sm:text-base font-normal leading-normal max-w-md mx-auto border border-white p-1">
-              Transform your daily routine into an epic journey. Discover hidden gems and embark on real-world quests.
-            </h2>
-          </div>
-
-          <div className="flex-wrap gap-3 flex justify-center mt-4 border-4 border-red-100 p-2">
-            <button
-              onClick={onStart}
-              className="flex min-w-[84px] max-w-[480px] items-center justify-center rounded-full h-10 px-4 sm:h-12 sm:px-5 bg-[#019863] text-[#f8fcfa] text-sm sm:text-base font-bold tracking-wide border border-white"
-            >
-              <span className="truncate">Begin Your Quest</span>
-            </button>
-            <button className="flex min-w-[84px] max-w-[480px] items-center justify-center rounded-full h-10 px-4 sm:h-12 sm:px-5 bg-[#e6f4ef] text-[#0c1c17] text-sm sm:text-base font-bold tracking-wide border border-white">
-              <span className="truncate">Sign In with Explorer Account</span>
-            </button>
-          </div>
+    <div className="min-h-screen flex flex-col bg-gradient-to-br from-green-50 to-green-100 text-[#0e1b0e]">
+      <header className="p-4 flex justify-between items-center">
+        <span className="font-bold text-xl">Roamio</span>
+        <button onClick={handleLogin} className="text-sm font-medium text-blue-700 underline">
+          Sign In
+        </button>
+      </header>
+      <div className="flex flex-1 flex-col items-center justify-center text-center px-6">
+        <h1 className="text-4xl md:text-5xl font-extrabold mb-2">Uncover Your Next Adventure</h1>
+        <p className="text-lg text-[#4e974e] mb-6 max-w-xl">
+          Explore your world through epic quests. Gamify your day with real places, stories, and surprises.
+        </p>
+        <div className="flex gap-4">
+          <button
+            onClick={demoQuest}
+            className="px-6 py-3 bg-white rounded-full shadow text-sm font-bold"
+          >
+            Preview Demo Quest
+          </button>
+          <button
+            onClick={handleLogin}
+            className="px-6 py-3 bg-[#019863] text-white rounded-full shadow text-sm font-bold"
+          >
+            Sign In to Begin
+          </button>
         </div>
+        <div className="mt-12 animate-bounce text-2xl">⤵</div>
       </div>
     </div>
   );

--- a/frontend/src/components/LiveQuestMap.jsx
+++ b/frontend/src/components/LiveQuestMap.jsx
@@ -1,50 +1,77 @@
 import GoogleMapReact from "google-map-react";
 import { useEffect, useRef } from "react";
 
-const UserMarker = () => <div className="text-2xl">🧍‍♂️</div>;
-
-const StopMarker = ({ visited, current }) => (
-  <div className={`text-2xl ${current ? "text-green-600" : visited ? "text-gray-400" : "text-red-500"}`}>
-    📍
+const UserMarker = () => (
+  <div className="relative flex items-center justify-center">
+    <div className="absolute h-4 w-4 rounded-full bg-blue-400 opacity-75 animate-ping" />
+    <div className="relative h-3 w-3 rounded-full bg-blue-600" />
   </div>
 );
 
-export default function LiveQuestMap({ stops = [], visitedIndex = 0, userLocation }) {
+const StopMarker = ({ visited, current, final, name }) => {
+  let icon = "📍";
+  if (final) icon = "🏁";
+  if (current) icon = "⭐";
+  if (visited && !current) icon = "✅";
+  return (
+    <div title={name} className="text-2xl">
+      {icon}
+    </div>
+  );
+};
+
+export default function LiveQuestMap({
+  stops = [],
+  visitedIndex = 0,
+  userLocation,
+  polylinePoints = [],
+}) {
   const mapRef = useRef(null);
   const mapsRef = useRef(null);
+  const polyRef = useRef(null);
 
-  const drawRoute = () => {
-    if (!mapRef.current || !mapsRef.current || stops.length < 2) return;
-
-    const directionsService = new mapsRef.current.DirectionsService();
-    const directionsRenderer = new mapsRef.current.DirectionsRenderer({ suppressMarkers: true });
-    directionsRenderer.setMap(mapRef.current);
-
-    directionsService.route(
-      {
-        origin: stops[0],
-        destination: stops[stops.length - 1],
-        waypoints: stops.slice(1, -1).map((s) => ({ location: s })),
-        travelMode: mapsRef.current.TravelMode.WALKING,
-      },
-      (result, status) => {
-        if (status === "OK") {
-          directionsRenderer.setDirections(result);
-        } else {
-          console.error("Directions request failed due to " + status);
-        }
-      }
-    );
+  const drawPolyline = () => {
+    if (!mapRef.current || !mapsRef.current) return;
+    if (polyRef.current) {
+      polyRef.current.setMap(null);
+      polyRef.current = null;
+    }
+    if (!polylinePoints.length) return;
+    const path = polylinePoints.map((p) => new mapsRef.current.LatLng(p.lat, p.lng));
+    polyRef.current = new mapsRef.current.Polyline({
+      path,
+      geodesic: true,
+      strokeColor: "#019863",
+      strokeOpacity: 0.9,
+      strokeWeight: 5,
+    });
+    polyRef.current.setMap(mapRef.current);
   };
 
   useEffect(() => {
-    drawRoute();
-  }, [stops]);
+    drawPolyline();
+  }, [polylinePoints]);
+
+  const panTimeout = useRef(null);
+
+  useEffect(() => {
+    if (!mapRef.current || !userLocation) return;
+    if (panTimeout.current) clearTimeout(panTimeout.current);
+    panTimeout.current = setTimeout(() => {
+      mapRef.current.panTo(userLocation);
+    }, 500);
+  }, [userLocation]);
+
+  useEffect(() => {
+    if (!mapRef.current || !stops.length) return;
+    const target = stops[visitedIndex] || stops[stops.length - 1];
+    mapRef.current.panTo(target);
+  }, [visitedIndex, stops]);
 
   const center = userLocation || stops[0];
 
   return (
-    <div className="h-[300px] w-full rounded-xl overflow-hidden shadow-md">
+    <div className="w-full h-[60vh] max-h-[500px] rounded-xl overflow-hidden shadow-md">
       <GoogleMapReact
         bootstrapURLKeys={{ key: import.meta.env.VITE_GOOGLE_MAPS_API_KEY }}
         defaultCenter={center}
@@ -53,7 +80,7 @@ export default function LiveQuestMap({ stops = [], visitedIndex = 0, userLocatio
         onGoogleApiLoaded={({ map, maps }) => {
           mapRef.current = map;
           mapsRef.current = maps;
-          drawRoute();
+          drawPolyline();
         }}
       >
         {userLocation && <UserMarker lat={userLocation.lat} lng={userLocation.lng} />}
@@ -64,6 +91,8 @@ export default function LiveQuestMap({ stops = [], visitedIndex = 0, userLocatio
             lng={stop.lng}
             visited={idx < visitedIndex}
             current={idx === visitedIndex}
+            final={idx === stops.length - 1}
+            name={stop.name}
           />
         ))}
       </GoogleMapReact>

--- a/frontend/src/components/PaymentSuccess.jsx
+++ b/frontend/src/components/PaymentSuccess.jsx
@@ -1,12 +1,38 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { validatePremium } from '../lib/api';
 
-const PaymentSuccess = () => (
-  <div className="min-h-screen flex items-center justify-center bg-[#f8fcf8] px-6 py-10 text-center">
-    <div>
-      <h1 className="text-3xl font-bold text-green-700 mb-4">Payment Successful</h1>
-      <p className="text-[#0e1b0e]">Welcome to Quest+! Enjoy your new adventures.</p>
+const PaymentSuccess = () => {
+  const [params] = useSearchParams();
+  const [status, setStatus] = useState('Activating...');
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const uid = params.get('userId');
+    const session = params.get('session_id');
+    if (uid && session) {
+      validatePremium(uid, session)
+        .then((res) => {
+          if (res.premium) {
+            setStatus('Quest+ Activated!');
+          } else {
+            navigate('/payment-failed');
+          }
+        })
+        .catch(() => navigate('/payment-failed'));
+    } else {
+      navigate('/payment-failed');
+    }
+  }, [params]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-[#f8fcf8] px-6 py-10 text-center">
+      <div>
+        <h1 className="text-3xl font-bold text-green-700 mb-4">Payment Successful</h1>
+        <p className="text-[#0e1b0e]">{status}</p>
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default PaymentSuccess;

--- a/frontend/src/components/PlaceItem.jsx
+++ b/frontend/src/components/PlaceItem.jsx
@@ -26,6 +26,7 @@ export default function PlaceItem({ place }) {
   const name = place?.name || "Unnamed Place";
   const type = place?.type || "Unknown";
   const icon = typeIcons[type] || typeIcons["Unknown"];
+  const visit = place.visitDuration || 10;
   const mapsLink = `https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(name)}`;
 
   return (
@@ -39,7 +40,7 @@ export default function PlaceItem({ place }) {
       >
         <strong>{name}</strong>
       </a>
-      <span className="text-sm text-gray-500">({type})</span>
+      <span className="text-sm text-gray-500">({type}, ~{visit} min)</span>
     </li>
   );
 }

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -54,7 +54,14 @@ const Profile = () => {
         {stats.mostCity && <p>Most visited city: {stats.mostCity}</p>}
         {stats.longest > 0 && <p>Longest quest: {stats.longest} stops</p>}
       </div>
-      <PostcardGallery />
+      {premium ? (
+        <PostcardGallery />
+      ) : (
+        <div className="text-center space-y-2">
+          <p className="text-sm">Quest+ membership required to view your full postcard history.</p>
+          <a href="/quest-plus" className="text-blue-600 underline">Upgrade to Quest+</a>
+        </div>
+      )}
     </div>
   );
 };

--- a/frontend/src/components/PublicQuestPage.jsx
+++ b/frontend/src/components/PublicQuestPage.jsx
@@ -1,0 +1,164 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  getCustomQuest,
+  createCustomQuest,
+  createGroupQuest,
+  likeQuest,
+  viewQuest,
+  replayQuest,
+} from '../lib/api';
+import { getAuth } from 'firebase/auth';
+
+const toQuestObj = (doc) => {
+  if (!doc || !doc.fields) return null;
+  const _from = (v) => {
+    if (v.stringValue !== undefined) return v.stringValue;
+    if (v.integerValue !== undefined) return parseInt(v.integerValue, 10);
+    if (v.doubleValue !== undefined) return v.doubleValue;
+    if (v.arrayValue) return (v.arrayValue.values || []).map(_from);
+    if (v.mapValue) {
+      const obj = {};
+      for (const [k, val] of Object.entries(v.mapValue.fields || {})) {
+        obj[k] = _from(val);
+      }
+      return obj;
+    }
+    return null;
+  };
+  const out = {};
+  for (const [k, val] of Object.entries(doc.fields)) {
+    out[k] = _from(val);
+  }
+  return out;
+};
+
+export default function PublicQuestPage() {
+  const { questId } = useParams();
+  const [quest, setQuest] = useState(null);
+  const [copied, setCopied] = useState(false);
+  const [liked, setLiked] = useState(false);
+  const navigate = useNavigate();
+  const auth = getAuth();
+  const user = auth.currentUser;
+
+  useEffect(() => {
+    getCustomQuest(questId)
+      .then((doc) => setQuest(toQuestObj(doc)))
+      .catch((err) => console.error('fetch quest failed', err));
+    if (user) {
+      viewQuest(user.uid, questId).catch(() => {});
+    }
+  }, [questId]);
+
+  const handleStart = async () => {
+    if (!user) return navigate('/');
+    try {
+      const payload = {
+        user_id: user.uid,
+        title: quest.title,
+        mood_tags: quest.moodTags,
+        places: quest.places.map((p) => ({
+          name: p.name,
+          place_id: p.place_id,
+          lat: p.lat,
+          lng: p.lng,
+          duration_minutes: p.duration_minutes,
+        })),
+        time_limit: quest.timeLimit,
+        custom_prompt: quest.customPrompt,
+      };
+      const res = await createCustomQuest(payload);
+      const group = await createGroupQuest(user.uid, res.questId, user.displayName);
+      await replayQuest(questId).catch(() => {});
+      navigate('/live', { state: { quest, questId: res.questId, groupId: group.groupId } });
+    } catch (err) {
+      console.error('start failed', err);
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!user) return navigate('/');
+    try {
+      await createCustomQuest({
+        user_id: user.uid,
+        title: quest.title,
+        mood_tags: quest.moodTags,
+        places: quest.places,
+        time_limit: quest.timeLimit,
+        custom_prompt: quest.customPrompt,
+        status: 'draft',
+      });
+      await replayQuest(questId).catch(() => {});
+      setCopied(true);
+    } catch (err) {
+      console.error('copy failed', err);
+    }
+  };
+
+  if (!quest) return <div className="p-6">Loading...</div>;
+
+  const totalTime = quest.places.reduce((t, p) => t + (p.duration_minutes || 0), 0);
+  const shareLink = `${window.location.origin}/q/${questId}`;
+
+  const handleLike = async () => {
+    if (!user || liked) return;
+    try {
+      await likeQuest(user.uid, questId);
+      setLiked(true);
+    } catch (err) {
+      console.error('like failed', err);
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto p-6 space-y-4 text-[#0e1b0e]">
+      <h1 className="text-2xl font-bold">{quest.title}</h1>
+      <div className="text-sm">Mood: {quest.moodTags?.join(', ')}</div>
+      <div className="text-sm">Estimated Time: {totalTime} mins</div>
+      <div className="text-sm flex gap-4">
+        <span>❤️ {quest.likesCount || 0}</span>
+        <span>👁️ {quest.viewsCount || 0}</span>
+        <span>🔄 {quest.replaysCount || 0}</span>
+      </div>
+      <ol className="list-decimal pl-5 space-y-1">
+        {quest.places.map((p, idx) => (
+          <li key={idx}>{p.name} ({p.duration_minutes} min)</li>
+        ))}
+      </ol>
+      <button
+        className="mt-4 px-4 py-2 bg-green-600 text-white rounded"
+        onClick={handleStart}
+      >
+        Start this Quest!
+      </button>
+      {user && user.uid !== quest.createdBy && (
+        <button
+          className="ml-2 px-3 py-2 border rounded"
+          onClick={handleCopy}
+        >
+          {copied ? 'Copied!' : 'Copy Quest'}
+        </button>
+      )}
+      {user && (
+        <button
+          className="ml-2 px-3 py-2 border rounded"
+          onClick={handleLike}
+        >
+          {liked ? 'Liked!' : 'Like this Quest'}
+        </button>
+      )}
+      <div className="mt-4">
+        <button
+          className="text-blue-600 underline"
+          onClick={() => {
+            navigator.clipboard.writeText(shareLink);
+            setCopied(true);
+          }}
+        >
+          {copied ? 'Link Copied' : 'Copy Share Link'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/QuestHome.jsx
+++ b/frontend/src/components/QuestHome.jsx
@@ -1,6 +1,21 @@
 import React, { useState, useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { generateQuest } from "../lib/api.js";
+import { generateQuest, createGroupQuest, getActiveQuest, getQuest, leaveGroup, validatePremium } from "../lib/api.js";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "../firebase";
+
+const _toQuestObj = (doc) => {
+  if (!doc || !doc.fields) return doc;
+  return Object.keys(doc.fields).reduce((acc, k) => {
+    const v = doc.fields[k];
+    if (v.stringValue !== undefined) acc[k] = v.stringValue;
+    else if (v.integerValue !== undefined) acc[k] = parseInt(v.integerValue, 10);
+    else if (v.doubleValue !== undefined) acc[k] = v.doubleValue;
+    else if (v.arrayValue) acc[k] = (v.arrayValue.values || []).map(_toQuestObj);
+    else if (v.mapValue) acc[k] = _toQuestObj({ fields: v.mapValue.fields || {} });
+    return acc;
+  }, {});
+};
 import { getAuth, onAuthStateChanged, signInWithPopup, GoogleAuthProvider } from "firebase/auth";
 import PlaceItem from "./PlaceItem";
 import RouteMap from "./RouteMap";
@@ -26,15 +41,64 @@ const QuestHome = () => {
   const [error, setError] = useState("");
   const [questResult, setQuestResult] = useState(null);
   const [user, setUser] = useState(null);
+  const [premium, setPremium] = useState(false);
+  const [resumeData, setResumeData] = useState(null);
   const navigate = useNavigate();
 
   useEffect(() => {
     const auth = getAuth();
-    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+    const unsubscribe = onAuthStateChanged(auth, async (firebaseUser) => {
       setUser(firebaseUser);
+      if (firebaseUser) {
+        try {
+          const res = await validatePremium(firebaseUser.uid);
+          setPremium(!!res.premium);
+        } catch (err) {
+          console.error('premium check failed', err);
+        }
+      } else {
+        setPremium(false);
+      }
     });
     return () => unsubscribe();
   }, []);
+
+  useEffect(() => {
+    if (!user) return;
+    (async () => {
+      try {
+        const data = await getActiveQuest(user.uid);
+        if (data && data.questId && data.status !== 'completed') {
+          const questDoc = await getQuest(data.questId).catch(() => null);
+          let groupOk = true;
+          if (data.groupId) {
+            const snap = await getDoc(doc(db, 'groups', data.groupId));
+            groupOk = snap.exists() && !snap.data().completed;
+          }
+          if (questDoc && groupOk) {
+            const questObj = _toQuestObj(questDoc);
+            if (Array.isArray(data.trimmedPlaces)) {
+              questObj.places = data.trimmedPlaces;
+            }
+            setResumeData({
+              quest: questObj,
+              groupId: data.groupId,
+              questId: data.questId,
+              status: data.status,
+              usedTimeLimit: data.usedTimeLimit,
+            });
+          } else {
+            if (data.groupId) await leaveGroup(data.groupId, user.uid);
+            setResumeData(null);
+          }
+        } else {
+          setResumeData(null);
+        }
+      } catch (err) {
+        console.error('Failed to load active quest', err);
+      }
+    })();
+  }, [user]);
 
   const handleLogin = async () => {
     const auth = getAuth();
@@ -50,6 +114,11 @@ const QuestHome = () => {
   const handleGenerate = async () => {
     setError("");
     setQuestResult(null);
+
+    if (!premium) {
+      navigate('/quest-plus');
+      return;
+    }
 
     if (!user) {
       setError("You must be signed in to generate a quest.");
@@ -74,6 +143,28 @@ const QuestHome = () => {
     }
   };
 
+  const handleStartQuest = async () => {
+    if (!premium) {
+      navigate('/quest-plus');
+      return;
+    }
+    if (!questResult) return;
+    const questId = `${city}_${mood.join('-')}`;
+    try {
+      const { groupId } = await createGroupQuest(
+        user.uid,
+        questId,
+        user.displayName
+      );
+      navigate('/live', {
+        state: { quest: questResult.quest, questId, groupId, timeLimit },
+      });
+    } catch (err) {
+      console.error('Failed to create group', err);
+      setError('Failed to start group quest');
+    }
+  };
+
   const toggleMood = (selectedMood) => {
     if (mood.includes(selectedMood)) {
       setMood(mood.filter((m) => m !== selectedMood));
@@ -87,6 +178,18 @@ const QuestHome = () => {
   return (
     <div className="min-h-screen bg-[#f8fcf8] px-6 py-8 text-[#0e1b0e] font-sans">
       <h1 className="text-[32px] font-bold mb-6 text-center">Create a New Quest</h1>
+      {resumeData && (
+        <div className="mb-6 text-center">
+          <button
+            onClick={() =>
+              navigate('/live', { state: { quest: resumeData.quest, questId: resumeData.questId, groupId: resumeData.groupId, timeLimit: resumeData.usedTimeLimit } })
+            }
+            className="bg-blue-600 text-white px-4 py-2 rounded-lg"
+          >
+            Resume Quest
+          </button>
+        </div>
+      )}
 
       {!user ? (
         <div className="text-center space-y-4">
@@ -163,18 +266,25 @@ const QuestHome = () => {
               />
 
               <button
-                onClick={() =>
-                  navigate('/live', {
-                    state: {
-                      quest: questResult.quest,
-                      questId: `${city}_${mood.join('-')}`,
-                    },
-                  })
-                }
-                className="mt-4 w-full bg-[#14b714] text-white py-2 rounded-lg font-bold hover:bg-[#0fa50f] transition"
+                onClick={handleStartQuest}
+                disabled={!!resumeData}
+                className={`mt-4 w-full py-2 rounded-lg font-bold transition text-white ${
+                  resumeData ? 'bg-gray-400 cursor-not-allowed' : 'bg-[#14b714] hover:bg-[#0fa50f]'
+                }`}
               >
                 Start Quest
               </button>
+              {!premium && (
+                <p className="text-center text-xs mt-1">
+                  Quest+ required to start quests.{' '}
+                  <a href="/quest-plus" className="text-blue-600 underline">Upgrade</a>
+                </p>
+              )}
+              {resumeData && (
+                <p className="text-center text-sm text-red-600 mt-1">
+                  You have a quest in progress.
+                </p>
+              )}
 
             </div>
           )}

--- a/frontend/src/components/QuestLivePage.jsx
+++ b/frontend/src/components/QuestLivePage.jsx
@@ -1,19 +1,34 @@
 import React, { useEffect, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { useLocation, useNavigate } from "react-router-dom";
 import LiveQuestMap from "./LiveQuestMap";
+import GroupMemberList from "./GroupMemberList";
 import { getAuth } from "firebase/auth";
-import { trackVisit, getUserQuests, completeQuest } from "../lib/api";
+import { trackVisit, getUserQuests, completeQuest, joinGroup, trackStopVisit, completeGroupQuest, leaveGroup, reportQuest, updateActiveQuest } from "../lib/api";
+import { doc, onSnapshot } from "firebase/firestore";
+import { db } from "../firebase";
+import { decode } from "@googlemaps/polyline-codec";
 
 
 export default function QuestLivePage() {
   const location = useLocation();
+  const navigate = useNavigate();
   const quest = location.state?.quest;
   const questId = location.state?.questId;
+  const groupId = location.state?.groupId || new URLSearchParams(location.search).get('groupId');
+  const initialLimit = location.state?.timeLimit ? Number(location.state.timeLimit) : 90;
 
   const [userLocation, setUserLocation] = useState(null);
   const [stops, setStops] = useState([]);
+  const timeLimit = initialLimit;
   const [visitedIndices, setVisitedIndices] = useState([]);
+  const [groupData, setGroupData] = useState(null);
+  const [activityMsg, setActivityMsg] = useState("");
+  const [copied, setCopied] = useState(false);
+  const [showComplete, setShowComplete] = useState(false);
   const [etaText, setEtaText] = useState("");
+  const [etaError, setEtaError] = useState("");
+  const [etaRefresh, setEtaRefresh] = useState(0);
+  const [polylinePoints, setPolylinePoints] = useState([]);
   const [saving, setSaving] = useState(false);
   const [completeMsg, setCompleteMsg] = useState("");
 
@@ -34,15 +49,116 @@ export default function QuestLivePage() {
     }
   }, []);
 
-  // Update stops list when we have user location or quest
+  // Base stops from quest data
   useEffect(() => {
-    if (!quest || !userLocation) return;
-    const questStops = quest.places.map((p) => ({ lat: parseFloat(p.lat), lng: parseFloat(p.lng) }));
-    setStops([{ lat: userLocation.lat, lng: userLocation.lng }, ...questStops]);
-  }, [quest, userLocation]);
+    if (!quest) return;
+    const questStops = quest.places.map((p) => ({ lat: parseFloat(p.lat), lng: parseFloat(p.lng), name: p.name }));
+    setStops(questStops);
+  }, [quest]);
 
-  // Load progress from backend
+  // Optimize order and trim stops using current location
   useEffect(() => {
+    if (!quest || !userLocation || !quest.places?.length) return;
+    const fetchOptimized = async () => {
+      const VISIT_SEC = 10 * 60; // assumed time spent at each stop
+      const key = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+      const coords = quest.places.map((p) => `${p.lat},${p.lng}`);
+      if (coords.length < 2) return;
+
+      const origin = `${userLocation.lat},${userLocation.lng}`;
+      const destination = coords[coords.length - 1];
+      const waypointStr = coords.slice(0, -1).join('|');
+      try {
+        const res = await fetch(
+          `https://maps.googleapis.com/maps/api/directions/json?origin=${origin}&destination=${destination}&waypoints=optimize:true|${waypointStr}&mode=walking&key=${key}`
+        );
+        const data = await res.json();
+        const order = data?.routes?.[0]?.waypoint_order;
+        let ordered = quest.places;
+        if (Array.isArray(order) && order.length === coords.length - 1) {
+          ordered = order.map((i) => quest.places[i]);
+          ordered.push(quest.places[quest.places.length - 1]);
+        }
+
+        const legs = data?.routes?.[0]?.legs || [];
+        const limitSec = timeLimit * 60;
+        let total = 0;
+        let keep = legs.length;
+        for (let i = 0; i < legs.length; i++) {
+          total += legs[i]?.duration?.value || 0;
+          total += VISIT_SEC;
+          if (total > limitSec) {
+            keep = i + 1;
+            break;
+          }
+        }
+        if (keep === 0) {
+          keep = 1;
+          alert('Time limit too short for full quest; using first stop only.');
+        }
+        const trimmed = ordered.slice(0, keep);
+        setStops(trimmed.map((p) => ({ lat: parseFloat(p.lat), lng: parseFloat(p.lng), name: p.name })));
+
+        try {
+          const auth = getAuth();
+          const user = auth.currentUser;
+          if (user) {
+            await updateActiveQuest(user.uid, {
+              optimizedOrder: order,
+              trimmedPlaces: trimmed,
+              usedTimeLimit: timeLimit,
+            });
+          }
+        } catch (err) {
+          console.error('failed to store optimized order', err);
+        }
+
+        const poly = data?.routes?.[0]?.overview_polyline?.points;
+        if (poly) {
+          const decoded = decode(poly).map(([lat, lng]) => ({ lat, lng }));
+          setPolylinePoints(decoded);
+        }
+      } catch (err) {
+        console.error('Failed to fetch optimized route', err);
+      }
+    };
+    fetchOptimized();
+  }, [quest, userLocation, timeLimit]);
+
+  // Join group and listen for progress
+  useEffect(() => {
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user || !groupId) return;
+    joinGroup(user.uid, groupId, user.displayName).catch((e) => console.error('join failed', e));
+    let prev = null;
+    const unsub = onSnapshot(doc(db, 'groups', groupId), (snap) => {
+      const data = snap.data();
+      if (!data) return;
+      setGroupData(data);
+      if (data.progress && data.progress[user.uid]) {
+        setVisitedIndices(data.progress[user.uid]);
+      }
+      if (prev && data.progress) {
+        Object.keys(data.progress).forEach((uid) => {
+          if (uid === user.uid) return;
+          const before = (prev.progress?.[uid] || []).length;
+          const after = (data.progress[uid] || []).length;
+          if (after > before) {
+            const member = data.members?.find((m) => m.userId === uid);
+            setActivityMsg(`${member?.displayName || uid} visited stop ${after}`);
+            setTimeout(() => setActivityMsg(''), 3000);
+          }
+        });
+      }
+      prev = data;
+    });
+    return () => unsub();
+  }, [groupId]);
+
+  // Load personal progress when not in group
+  useEffect(() => {
+    if (groupId) return;
     const auth = getAuth();
     const user = auth.currentUser;
     if (!user || !questId) return;
@@ -57,44 +173,78 @@ export default function QuestLivePage() {
         console.error('Failed to load progress', err);
       }
     })();
-  }, [quest]);
+  }, [quest, groupId, questId]);
 
   const currentStopIndex = visitedIndices.length;
-  const allVisited = visitedIndices.length >= (quest?.places?.length || 0);
+  const allVisited = stops.length > 0 && visitedIndices.length >= stops.length;
+  const questComplete = allVisited || groupData?.completed === true;
+
+  useEffect(() => {
+    if (questComplete) {
+      setShowComplete(true);
+      const t = setTimeout(() => setShowComplete(false), 3000);
+      return () => clearTimeout(t);
+    }
+  }, [questComplete]);
 
 
   useEffect(() => {
-    if (!userLocation || !stops[currentStopIndex]) return;
+    if (!userLocation || !stops.length) return;
+    const remaining = stops.slice(currentStopIndex);
+    if (!remaining.length) return;
 
-    const fetchETA = async () => {
+    const fetchRoute = async () => {
+      setEtaError("");
       const origin = `${userLocation.lat},${userLocation.lng}`;
-      const destination = `${stops[currentStopIndex].lat},${stops[currentStopIndex].lng}`;
       const key = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
+      const destination = `${remaining[remaining.length - 1].lat},${remaining[remaining.length - 1].lng}`;
+      const waypoints = remaining
+        .slice(0, -1)
+        .map((p) => `${p.lat},${p.lng}`)
+        .join('|');
+
+      const url = `https://maps.googleapis.com/maps/api/directions/json?origin=${origin}&destination=${destination}&mode=walking` +
+        (waypoints ? `&waypoints=${waypoints}` : '') +
+        `&key=${key}`;
 
       try {
-        const res = await fetch(
-          `https://maps.googleapis.com/maps/api/directions/json?origin=${origin}&destination=${destination}&mode=walking&key=${key}`
-        );
+        const res = await fetch(url);
         const data = await res.json();
-        const eta = data?.routes?.[0]?.legs?.[0]?.duration?.text;
-        if (eta) setEtaText(eta);
+        const legs = data?.routes?.[0]?.legs || [];
+        if (legs.length === 0) throw new Error('No route');
+        const sec = legs.reduce((s, l) => s + (l.duration?.value || 0), 0);
+        const mins = Math.round(sec / 60);
+        setEtaText(`${mins} min`);
+        const poly = data?.routes?.[0]?.overview_polyline?.points;
+        if (poly) {
+          const decoded = decode(poly).map(([lat, lng]) => ({ lat, lng }));
+          setPolylinePoints(decoded);
+        } else {
+          setPolylinePoints([]);
+        }
       } catch (err) {
-        console.error("Failed to fetch ETA:", err);
+        console.error('Failed to fetch directions:', err);
+        setEtaError('Failed to load ETA');
       }
     };
 
-    fetchETA();
-  }, [userLocation, currentStopIndex, stops]);
+    fetchRoute();
+  }, [userLocation, currentStopIndex, stops, etaRefresh]);
 
   const handleMarkVisited = async () => {
     const auth = getAuth();
     const user = auth.currentUser;
     if (!user) return alert("You must be logged in!");
 
-    if (!questId) return;
+    if (!questId || questComplete) return;
     try {
-      const res = await trackVisit(user.uid, questId, visitedIndices.length);
-      setVisitedIndices(res.visitedIndices || []);
+      if (groupId) {
+        const res = await trackStopVisit(groupId, user.uid, visitedIndices.length);
+        setVisitedIndices(res.visitedStops || res.visitedIndices || []);
+      } else {
+        const res = await trackVisit(user.uid, questId, visitedIndices.length);
+        setVisitedIndices(res.visitedIndices || []);
+      }
     } catch (err) {
       console.error('Failed to track visit', err);
     }
@@ -108,6 +258,7 @@ export default function QuestLivePage() {
     setSaving(true);
     setCompleteMsg("");
     try {
+      const share = window.confirm('Share this quest publicly?');
       await completeQuest(user.uid, questId, {
         title: quest.title,
         city: quest.city,
@@ -118,7 +269,12 @@ export default function QuestLivePage() {
         imagePrompt: quest.imagePrompt,
         imageUrl: quest.imageUrl,
         visitedIndices,
+        public: share,
+        displayName: user.displayName,
       });
+      if (groupId) {
+        await completeGroupQuest(groupId, user.uid);
+      }
       setCompleteMsg("Quest Saved to Your Profile!");
       window.dispatchEvent(new Event("quest-saved"));
     } catch (err) {
@@ -130,12 +286,43 @@ export default function QuestLivePage() {
 
   };
 
+  const handleReport = async () => {
+    const reason = window.prompt('Reason for report?');
+    if (!reason) return;
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user) return alert('You must be logged in!');
+    try {
+      await reportQuest(user.uid, questId, reason, quest.city, quest.mood);
+      alert('Report submitted');
+    } catch (err) {
+      console.error('failed to report quest', err);
+    }
+  };
+
+  const handleLeave = async () => {
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user || !groupId) return;
+    try {
+      await leaveGroup(groupId, user.uid);
+      navigate('/home');
+    } catch (err) {
+      console.error('failed to leave group', err);
+    }
+  };
+
   if (!quest) {
     return <div className="p-6 text-center text-red-600">Quest data missing.</div>;
   }
 
   return (
     <div className="relative flex min-h-screen flex-col bg-[#f8fcf8] overflow-x-hidden font-jakarta">
+      {showComplete && (
+        <div className="absolute inset-0 z-10 flex items-center justify-center bg-white/80 text-3xl font-bold animate-bounce">
+          Quest Complete!
+        </div>
+      )}
       <div className="flex h-full flex-col">
         <header className="flex items-center justify-between border-b border-[#e7f3e7] px-10 py-3">
           <div className="flex items-center gap-4 text-[#0e1b0e]">
@@ -173,65 +360,120 @@ export default function QuestLivePage() {
 
         <main className="px-10 py-5 flex flex-col max-w-4xl mx-auto w-full">
           <div className="flex flex-wrap justify-between gap-3 p-4">
-            <div className="flex flex-col gap-3 min-w-72">
-              <p className="text-2xl font-bold text-[#0e1b0e]">
-                {quest?.title || "Your Quest"}
-              </p>
-              <p className="text-sm text-[#4e974e]">
-                {quest?.questText || "Embark on your adventure"}
-              </p>
+          <div className="flex flex-col gap-3 min-w-72">
+            <p className="text-2xl font-bold text-[#0e1b0e]">
+              {quest?.title || "Your Quest"}
+            </p>
+            <p className="text-sm text-[#4e974e]">
+              {quest?.questText || "Embark on your adventure"}
+            </p>
+            {groupId && (
+              <div className="text-xs text-blue-700 space-y-1">
+                <div className="flex items-center gap-2">
+                  <span className="break-all">Invite: {`${window.location.origin}/live?groupId=${groupId}`}</span>
+                  <button
+                    onClick={() => {
+                      navigator.clipboard.writeText(`${window.location.origin}/live?groupId=${groupId}`);
+                      setCopied(true);
+                      setTimeout(() => setCopied(false), 1500);
+                    }}
+                    className="px-2 py-0.5 rounded bg-blue-600 text-white"
+                  >
+                    {copied ? 'Copied!' : 'Copy'}
+                  </button>
+                </div>
+                {groupData && (
+                  <GroupMemberList members={groupData.members || []} progress={groupData.progress || {}} total={stops.length} />
+                )}
+              </div>
+            )}
+          </div>
+            <div className="flex gap-2">
+              {groupId && (
+                <button
+                  onClick={handleLeave}
+                  className="h-10 px-4 rounded-full bg-red-500 text-sm text-white"
+                >
+                  Leave Group
+                </button>
+              )}
+              <button
+                onClick={() => window.location.assign('/home')}
+                className="h-10 px-4 rounded-full bg-[#e7f3e7] text-sm text-[#0e1b0e]"
+              >
+                Back to Home
+              </button>
             </div>
-            <button
-              onClick={() => window.location.assign('/home')}
-              className="h-8 px-4 rounded-full bg-[#e7f3e7] text-sm text-[#0e1b0e]"
-            >
-              Back to Home
-            </button>
           </div>
 
           <div className="p-4">
             <div className="flex justify-between items-center">
               <p className="text-base font-medium text-[#0e1b0e]">Progress</p>
               <p className="text-sm text-[#0e1b0e]">
-                {visitedIndices.length}/{quest?.places?.length}
+                {visitedIndices.length}/{stops.length}
               </p>
             </div>
-            <div className="w-full bg-[#d0e7d0] rounded">
-              <div
-                className="h-2 rounded bg-[#14b714]"
-                style={{ width: `${(visitedIndices.length / (quest?.places?.length || 1)) * 100}%` }}
-              />
-            </div>
+          <div className="w-full bg-[#d0e7d0] rounded">
+            <div
+              className="h-2 rounded bg-[#14b714]"
+              style={{ width: `${(visitedIndices.length / (stops.length || 1)) * 100}%` }}
+            />
           </div>
+        </div>
+        {activityMsg && (
+          <p className="text-xs text-center text-blue-700 mt-1">{activityMsg}</p>
+        )}
 
           <div className="px-4 py-3">
-            <LiveQuestMap stops={stops} visitedIndex={currentStopIndex} userLocation={userLocation} />
+            <LiveQuestMap
+              stops={stops}
+              visitedIndex={currentStopIndex}
+              userLocation={userLocation}
+              polylinePoints={polylinePoints}
+            />
           </div>
 
           <p className="text-sm text-[#4e974e] text-center px-4">
-            {etaText ? `ETA to Next Stop: ${etaText}` : "Calculating ETA..."}
+            {etaError
+              ? `${etaError}`
+              : etaText
+              ? `ETA to Next Stop: ${etaText}`
+              : "Calculating ETA..."}
           </p>
+          {etaError && (
+            <div className="text-center mt-1">
+              <button
+                onClick={() => {
+                  setEtaError("");
+                  setEtaRefresh((c) => c + 1);
+                }}
+                className="text-xs underline text-blue-600"
+              >
+                Retry ETA
+              </button>
+            </div>
+          )}
 
           <div className="flex px-4 py-3">
             <button
               onClick={handleMarkVisited}
-              disabled={allVisited}
-              className={`flex-1 h-12 rounded-full text-base font-bold text-[#f8fcf8] ${
-                allVisited
+              disabled={questComplete}
+              className={`flex-1 h-14 rounded-full text-base font-bold text-[#f8fcf8] ${
+                questComplete
                   ? "bg-gray-400 cursor-not-allowed"
                   : "bg-[#14b714] hover:bg-[#0fa50f]"
               }`}
             >
-              {allVisited ? "Quest Complete!" : "Mark as Visited"}
+              {questComplete ? "Quest Complete!" : "Mark as Visited"}
             </button>
           </div>
 
-          {allVisited && (
+          {questComplete && (
             <div className="flex px-4 py-3">
               <button
                 onClick={handleComplete}
                 disabled={saving}
-                className="flex-1 h-12 rounded-full bg-blue-600 hover:bg-blue-700 text-base font-bold text-white"
+                className="flex-1 h-14 rounded-full bg-blue-600 hover:bg-blue-700 text-base font-bold text-white"
               >
                 {saving ? "Saving..." : "Complete Quest"}
               </button>
@@ -240,6 +482,11 @@ export default function QuestLivePage() {
           {completeMsg && (
             <p className="text-center text-green-700 mt-2">{completeMsg}</p>
           )}
+          <div className="px-4 py-2">
+            <button onClick={handleReport} className="text-xs text-red-600 underline">
+              Report Quest
+            </button>
+          </div>
         </main>
       </div>
     </div>

--- a/frontend/src/components/QuestPlusPage.jsx
+++ b/frontend/src/components/QuestPlusPage.jsx
@@ -1,11 +1,22 @@
 import React, { useState } from 'react';
+import { getAuth } from 'firebase/auth';
+import { createCheckoutSession } from '../lib/api';
 
 const QuestPlusPage = () => {
   const [loading, setLoading] = useState(false);
 
-  const handleCheckout = () => {
+  const handleCheckout = async () => {
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user) return alert('You must be logged in');
     setLoading(true);
-    window.location.href = 'https://buy.stripe.com/test_4gw4jA8AcdFr0Te8ww';
+    try {
+      const data = await createCheckoutSession(user.uid, user.email);
+      window.location.href = data.url;
+    } catch (err) {
+      console.error('Checkout failed', err);
+      setLoading(false);
+    }
   };
 
   return (

--- a/frontend/src/components/RouteMap.jsx
+++ b/frontend/src/components/RouteMap.jsx
@@ -39,15 +39,7 @@ const RouteMap = ({ places = [], route = null }) => {
   const orderedPlaces = places.filter(
     (p) => parseLatLng(p.lat) !== null && parseLatLng(p.lng) !== null
   );
-  console.log("Route legs:", route?.legs);
-    // ✅ Add logs here for debugging
-console.log("PLACES:", orderedPlaces);
-console.log("ROUTE LEGS:", route?.legs);
-console.log("LEG 0 FULL:", route?.legs?.[0]);
-console.log("LEG 0 DURATION:", route?.legs?.[0]?.duration);
-
-
-
+  // Debug logs removed for production
   if (!orderedPlaces.length) return null;
 
   const center = {

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -62,8 +62,10 @@ export async function uploadPostcard(userId, questId, imageUrl) {
   return resp.json();
 }
 
-export async function validatePremium(userId) {
-  const resp = await fetch(`${BASE_URL}/validate-premium/${userId}`);
+export async function validatePremium(userId, sessionId) {
+  const url = new URL(`${BASE_URL}/validate-premium/${userId}`);
+  if (sessionId) url.searchParams.set('session_id', sessionId);
+  const resp = await fetch(url.toString());
   if (!resp.ok) {
     throw new Error('Failed to validate premium');
   }
@@ -102,3 +104,247 @@ export async function trackVisit(userId, questId, placeIndex) {
   return resp.json();
 }
 
+
+export async function createGroupQuest(userId, questId, displayName) {
+  const resp = await fetch(`${BASE_URL}/create-group-quest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, questId, displayName })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to create group');
+  }
+  return resp.json();
+}
+
+export async function joinGroup(userId, groupId, displayName) {
+  const resp = await fetch(`${BASE_URL}/join-group`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, groupId, displayName })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to join group');
+  }
+  return resp.json();
+}
+
+export async function trackStopVisit(groupId, userId, placeIndex) {
+  const resp = await fetch(`${BASE_URL}/track-stop-visit`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ groupId, userId, placeIndex })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to track stop');
+  }
+  return resp.json();
+}
+
+export async function completeGroupQuest(groupId, userId) {
+  const resp = await fetch(`${BASE_URL}/complete-group-quest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ groupId, userId })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to complete group quest');
+  }
+  return resp.json();
+}
+
+export async function leaveGroup(groupId, userId) {
+  const resp = await fetch(`${BASE_URL}/leave-group`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ groupId, userId })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to leave group');
+  }
+  return resp.json();
+}
+
+export async function getActiveQuest(userId) {
+  const resp = await fetch(`${BASE_URL}/active-quest/${userId}`);
+  if (!resp.ok) {
+    return null;
+  }
+  return resp.json();
+}
+
+export async function getQuest(questId) {
+  const resp = await fetch(`${BASE_URL}/get-quest/${questId}`);
+  if (!resp.ok) {
+    throw new Error('Failed to fetch quest');
+  }
+  return resp.json();
+}
+
+export async function getCommunityQuests() {
+  const resp = await fetch(`${BASE_URL}/get-community-quests`);
+  if (!resp.ok) {
+    throw new Error('Failed to load community quests');
+  }
+  return resp.json();
+}
+
+export async function reportQuest(userId, questId, reason, city, mood) {
+  const resp = await fetch(`${BASE_URL}/report-quest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, questId, reason, city, mood })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to report quest');
+  }
+  return resp.json();
+}
+
+export async function getQuestReports() {
+  const resp = await fetch(`${BASE_URL}/get-quest-reports`);
+  if (!resp.ok) {
+    throw new Error('Failed to load reports');
+  }
+  return resp.json();
+}
+
+export async function toggleQuestVisibility(questId, userId, visible) {
+  const resp = await fetch(`${BASE_URL}/toggle-quest-visibility`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ questId, userId, visible })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to update visibility');
+  }
+  return resp.json();
+}
+
+export async function createCheckoutSession(userId, email) {
+  const resp = await fetch(`${BASE_URL}/create-checkout-session`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, email, baseUrl: window.location.origin })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to create checkout session');
+  }
+  return resp.json();
+}
+
+export async function updateActiveQuest(userId, data) {
+  const resp = await fetch(`${BASE_URL}/update-active-quest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, data })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to update active quest');
+  }
+  return resp.json();
+}
+
+export async function createCustomQuest(payload) {
+  const resp = await fetch(`${BASE_URL}/create-custom-quest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload)
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to create custom quest');
+  }
+  return resp.json();
+}
+
+export async function getCustomQuest(id) {
+  const resp = await fetch(`${BASE_URL}/get-custom-quest/${id}`);
+  if (!resp.ok) {
+    throw new Error('Failed to fetch custom quest');
+  }
+  return resp.json();
+}
+
+export async function publishCustomQuest(userId, questId) {
+  const resp = await fetch(`${BASE_URL}/publish-custom-quest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: userId, quest_id: questId })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to publish quest');
+  }
+  return resp.json();
+}
+
+export async function likeQuest(userId, questId) {
+  const resp = await fetch(`${BASE_URL}/like-quest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: userId, quest_id: questId })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to like quest');
+  }
+  return resp.json();
+}
+
+export async function viewQuest(userId, questId) {
+  const resp = await fetch(`${BASE_URL}/view-quest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ user_id: userId, quest_id: questId })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to view quest');
+  }
+  return resp.json();
+}
+
+export async function replayQuest(questId) {
+  const resp = await fetch(`${BASE_URL}/replay-quest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ quest_id: questId })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to replay quest');
+  }
+  return resp.json();
+}
+
+export async function createCommunityGroup(data) {
+  const resp = await fetch(`${BASE_URL}/create-community-group`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data)
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to create group');
+  }
+  return resp.json();
+}
+
+export async function joinCommunityGroup(group_id, user_id) {
+  const resp = await fetch(`${BASE_URL}/join-community-group`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ group_id, user_id })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to join group');
+  }
+  return resp.json();
+}
+
+export async function linkQuestToGroup(group_id, quest_id, upcoming = false) {
+  const resp = await fetch(`${BASE_URL}/link-quest-to-group`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ group_id, quest_id, upcoming })
+  });
+  if (!resp.ok) {
+    throw new Error('Failed to link quest');
+  }
+  return resp.json();
+}


### PR DESCRIPTION
## Summary
- enrich custom quests with likes/views/replays counts
- implement `/like-quest`, `/view-quest`, `/replay-quest` and community group endpoints in backend
- expose helpers in `api.js`
- display social stats on shared quest pages and allow liking

## Testing
- `npm --prefix frontend run lint` *(with warnings)*
- `python -m py_compile backend/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6881177da2dc832198ba09841e0f1757