### PR TITLE
Add GPS quest option and polish UI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -282,6 +282,8 @@ async def generate_quest(
     time_limit: int = Body(...),
     token: str = Body(...),
     user_id: str | None = Body(None),
+    lat: float | None = Body(None),
+    lng: float | None = Body(None),
 ):
     """Generate a quest using tag-based filtering and optional GPT text."""
     if not city or not moods:
@@ -298,8 +300,11 @@ async def generate_quest(
             return JSONResponse(status_code=403, content={"error": "Daily quest limit reached"})
 
     try:
-        geocode = gmaps.geocode(city)
-        city_location = geocode[0]["geometry"]["location"]
+        if lat is not None and lng is not None:
+            city_location = {"lat": float(lat), "lng": float(lng)}
+        else:
+            geocode = gmaps.geocode(city)
+            city_location = geocode[0]["geometry"]["location"]
     except Exception as e:
         print(f"Geocoding error: {e}")
         return {"error": "Failed to locate city center."}
@@ -963,7 +968,9 @@ async def reroll_quest(payload: dict = Body(...)):
     time_limit = payload.get("time_limit", 60)
     token = payload.get("token", "")
     # Reuse generate_quest logic
-    return await generate_quest(city=city, moods=moods, time_limit=time_limit, token=token)
+    lat = payload.get("lat")
+    lng = payload.get("lng")
+    return await generate_quest(city=city, moods=moods, time_limit=time_limit, token=token, lat=lat, lng=lng)
 
 
 @app.post("/get-directions")

--- a/firestore.rules
+++ b/firestore.rules
@@ -48,6 +48,17 @@ service cloud.firestore {
       allow read, update, delete: if request.auth != null && request.auth.uid in resource.data.members && !isBanned();
     }
 
+    // ===== Communities =====
+    match /communities/{communityId} {
+      allow read: if true;
+      allow write: if request.auth != null && !isBanned();
+    }
+
+    // ===== Postcards =====
+    match /postcards/{userId}/{docId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId && !isBanned();
+    }
+
     // ===== Admin Config =====
     match /config/admins {
       allow read, write: if isAdmin();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,7 +17,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WanderQuest</title>
+    <title>Roamio</title>
 
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -24,7 +24,7 @@ const Header = () => {
   return (
     <header className="flex items-center justify-between px-6 py-4 border-b border-[#e6f4ef] bg-[#f8fcf8]">
       <Link to="/" className="text-xl font-bold text-[#0e1b0e]">
-        WanderQuest
+        Roamio
       </Link>
       <nav className="flex gap-4">
         <Link to="/home" className={linkClass("/home")}>Home</Link>

--- a/frontend/src/components/QuestHome.jsx
+++ b/frontend/src/components/QuestHome.jsx
@@ -37,6 +37,8 @@ const QuestHome = () => {
   const [city, setCity] = useState("");
   const [mood, setMood] = useState([]);
   const [timeLimit, setTimeLimit] = useState(90);
+  const [coords, setCoords] = useState(null);
+  const [gpsMsg, setGpsMsg] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [questResult, setQuestResult] = useState(null);
@@ -111,6 +113,24 @@ const QuestHome = () => {
     }
   };
 
+  const requestGps = () => {
+    if (!navigator.geolocation) {
+      setGpsMsg("Geolocation not supported");
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setCoords({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+        setGpsMsg("");
+      },
+      (err) => {
+        console.error("Geolocation error", err);
+        setCoords(null);
+        setGpsMsg("Location not shared — routing may be less accurate");
+      }
+    );
+  };
+
   const handleGenerate = async () => {
     setError("");
     setQuestResult(null);
@@ -128,7 +148,14 @@ const QuestHome = () => {
     setLoading(true);
     try {
       const token = await user.getIdToken();
-      const result = await generateQuest(city, mood, Number(timeLimit), token, user.uid);
+      const result = await generateQuest(
+        city,
+        mood,
+        Number(timeLimit),
+        token,
+        user.uid,
+        coords
+      );
       if (result.error) {
         console.error('❌ API error:', result);
         setError(result.error || 'Something went wrong generating your quest.');
@@ -211,6 +238,14 @@ const QuestHome = () => {
               onChange={(e) => setCity(e.target.value)}
               className="w-full px-4 py-2 border border-[#d0e7d0] rounded-lg focus:outline-none"
             />
+            <button
+              type="button"
+              onClick={requestGps}
+              className="text-sm underline text-blue-600"
+            >
+              {coords ? 'Location Set ✓' : 'Use My Location'}
+            </button>
+            {gpsMsg && <p className="text-xs text-red-600">{gpsMsg}</p>}
 
             <div className="flex flex-wrap gap-2">
               {moodOptions.map((option) => (
@@ -228,12 +263,18 @@ const QuestHome = () => {
               ))}
             </div>
 
-            <input
-              type="number"
-              value={String(timeLimit ?? "")}
-              onChange={(e) => setTimeLimit(Number(e.target.value) || 0)}
-              className="w-full px-4 py-2 border border-[#d0e7d0] rounded-lg focus:outline-none"
-            />
+            <label className="block text-sm font-medium text-[#0e1b0e]">
+              Time Limit: {timeLimit} minutes
+              <input
+                type="range"
+                min="15"
+                max="180"
+                step="15"
+                value={timeLimit}
+                onChange={(e) => setTimeLimit(Number(e.target.value))}
+                className="w-full mt-1"
+              />
+            </label>
 
             <button
               onClick={handleGenerate}

--- a/frontend/src/components/QuestLivePage.jsx
+++ b/frontend/src/components/QuestLivePage.jsx
@@ -234,6 +234,9 @@ export default function QuestLivePage() {
         .map((p) => `${p.lat},${p.lng}`)
         .join('|');
 
+      console.log('Waypoints', waypoints);
+      console.log('Remaining stops', remaining);
+
       const url = `https://maps.googleapis.com/maps/api/directions/json?origin=${origin}&destination=${destination}&mode=walking` +
         (waypoints ? `&waypoints=${waypoints}` : '') +
         `&key=${key}`;
@@ -246,6 +249,7 @@ export default function QuestLivePage() {
         const sec = legs.reduce((s, l) => s + (l.duration?.value || 0), 0);
         const mins = Math.round(sec / 60);
         setEtaText(`${mins} min`);
+        console.log('ETA legs', legs.map((l) => l.duration?.text));
         const poly = data?.routes?.[0]?.overview_polyline?.points;
         if (poly) {
           const decoded = decode(poly).map(([lat, lng]) => ({ lat, lng }));

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -7,7 +7,7 @@ const BASE_URL = import.meta.env.VITE_BACKEND_URL || "http://localhost:8080";
  * @param {number} timeLimit - Time limit in minutes
  * @param {string} token - Firebase user token for auth
  */
-export async function generateQuest(city, mood, timeLimit, token, userId) {
+export async function generateQuest(city, mood, timeLimit, token, userId, coords) {
   if (!city || !Array.isArray(mood) || mood.length === 0 || typeof timeLimit !== 'number') {
     throw new Error("Invalid input: city, mood[], and numeric timeLimit are required.");
   }
@@ -25,6 +25,8 @@ export async function generateQuest(city, mood, timeLimit, token, userId) {
       time_limit: timeLimit,
       token,
       user_id: userId,
+      lat: coords?.lat,
+      lng: coords?.lng,
     }),
   });
 


### PR DESCRIPTION
## Summary
- integrate optional GPS coordinates in quest generation
- switch time limit input to slider
- rebrand header and page title to Roamio
- log directions waypoints and legs for ETA debugging
- update Firestore rules with communities and postcards access

## Testing
- `node tests/firestoreRules.test.js` *(fails: Firestore emulator host/port not specified)*

------
https://chatgpt.com/codex/tasks/task_e_6881a15ed3b0832188b419ec204752de