### PR TITLE
Add GPS fallback and start location

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -254,6 +254,13 @@ def fill_template(template: str, city: str, mood: str, places: list[dict]) -> st
 
 app = FastAPI()
 
+# Manual fallbacks for vague regions
+CITY_FALLBACK_MAP = {
+    "hudson valley": "New York",
+    "catskills": "Albany",
+    "poconos": "Philadelphia",
+}
+
 # ✅ Replace this with your actual frontend deployed domain
 allowed_origins = [
     "http://localhost:5173",  # Vite dev server (local)
@@ -282,6 +289,8 @@ async def generate_quest(
     time_limit: int = Body(...),
     token: str = Body(...),
     user_id: str | None = Body(None),
+    lat: float | None = Body(None),
+    lng: float | None = Body(None),
 ):
     """Generate a quest using tag-based filtering and optional GPT text."""
     if not city or not moods:
@@ -298,11 +307,98 @@ async def generate_quest(
             return JSONResponse(status_code=403, content={"error": "Daily quest limit reached"})
 
     try:
-        geocode = gmaps.geocode(city)
-        city_location = geocode[0]["geometry"]["location"]
+        if lat is not None and lng is not None:
+            city_location = {"lat": float(lat), "lng": float(lng)}
+        else:
+            geocode = gmaps.geocode(city)
+            city_location = geocode[0]["geometry"]["location"]
     except Exception as e:
         print(f"Geocoding error: {e}")
         return {"error": "Failed to locate city center."}
+
+
+    attempts = 0
+    fallback_city = None
+    selected = []
+    while attempts < 2:
+        try:
+            response = gmaps.places_nearby(
+                location=(city_location["lat"], city_location["lng"]),
+                radius=2000,
+                type="tourist_attraction",
+            )
+            places_results = response.get("results", [])
+        except Exception as e:
+            print(f"Places API error: {e}")
+            return {"error": "Failed to fetch places"}
+
+        candidates = []
+        for place in places_results:
+            try:
+                name = place.get("name")
+                if not name or is_chain(name):
+                    continue
+                pid = place.get("place_id")
+                cached_place = get_cached_place(pid) if pid else None
+                details = None
+                if not cached_place and pid:
+                    try:
+                        details = gmaps.place(pid)
+                    except Exception:
+                        details = None
+                tags = (
+                    cached_place.get("tags") if cached_place else compute_place_tags(place, details)
+                )
+                if not cached_place and pid:
+                    save_place_to_cache(pid, {"tags": tags, "name": name})
+                if preferred:
+                    overlap = len(set(tags) & set(preferred))
+                else:
+                    overlap = 1
+                if overlap <= 0:
+                    continue
+                loc = place["geometry"]["location"]
+                typ = place.get("types", ["Unknown"])[0]
+                candidates.append({
+                    "name": name,
+                    "type": typ,
+                    "lat": float(loc["lat"]),
+                    "lng": float(loc["lng"]),
+                    "tags": tags,
+                    "score": overlap,
+                    "rating": place.get("rating", 0),
+                })
+            except Exception as e:
+                print("Skipping place", e)
+        candidates.sort(key=lambda x: (x["score"], x["rating"]), reverse=True)
+
+        selected = []
+        seen_types = set()
+        for c in candidates:
+            if c["type"] in seen_types:
+                continue
+            selected.append(c)
+            seen_types.add(c["type"])
+            if len(selected) >= 5:
+                break
+
+        if len(selected) >= 3:
+            break
+
+        fallback_city = CITY_FALLBACK_MAP.get(city.lower())
+        if not fallback_city:
+            break
+        attempts += 1
+        try:
+            geo = gmaps.geocode(fallback_city)
+            city_location = geo[0]["geometry"]["location"]
+            city = fallback_city
+        except Exception as e:
+            print("Fallback geocode error", e)
+            break
+
+    if len(selected) < 3:
+        return {"error": "Not enough matching places"}
 
     loc_hash = f"{city_location['lat']:.2f}_{city_location['lng']:.2f}"
     tag_combo = "-".join(sorted(preferred)) if preferred else "none"
@@ -310,75 +406,18 @@ async def generate_quest(
     cached = get_cached_quest(hash_key)
     if cached:
         print("Using cached quest")
-        return {"quest": cached}
+        result = {"quest": cached}
+        if fallback_city:
+            result["fallbackCity"] = fallback_city
+        return result
 
-    try:
-        response = gmaps.places_nearby(
-            location=(city_location["lat"], city_location["lng"]),
-            radius=2000,
-            type="tourist_attraction",
-        )
-        places_results = response.get("results", [])
-    except Exception as e:
-        print(f"Places API error: {e}")
-        return {"error": "Failed to fetch places"}
-
-    candidates = []
-    for place in places_results:
-        try:
-            name = place.get("name")
-            if not name or is_chain(name):
-                continue
-            pid = place.get("place_id")
-            cached_place = get_cached_place(pid) if pid else None
-            details = None
-            if not cached_place and pid:
-                try:
-                    details = gmaps.place(pid)
-                except Exception:
-                    details = None
-            tags = (
-                cached_place.get("tags") if cached_place else compute_place_tags(place, details)
-            )
-            if not cached_place and pid:
-                save_place_to_cache(pid, {"tags": tags, "name": name})
-            if preferred:
-                overlap = len(set(tags) & set(preferred))
-            else:
-                overlap = 1
-            if overlap <= 0:
-                continue
-            loc = place["geometry"]["location"]
-            typ = place.get("types", ["Unknown"])[0]
-            candidates.append({
-                "name": name,
-                "type": typ,
-                "lat": float(loc["lat"]),
-                "lng": float(loc["lng"]),
-                "tags": tags,
-                "score": overlap,
-                "rating": place.get("rating", 0),
-            })
-        except Exception as e:
-            print("Skipping place", e)
-    candidates.sort(key=lambda x: (x["score"], x["rating"]), reverse=True)
-
-    selected = []
-    seen_types = set()
-    for c in candidates:
-        if c["type"] in seen_types:
-            continue
-        selected.append(c)
-        seen_types.add(c["type"])
-        if len(selected) >= 5:
-            break
-
-    if len(selected) < 3:
-        return {"error": "Not enough matching places"}
-
-    origin = f"{selected[0]['lat']},{selected[0]['lng']}"
+    if lat is not None and lng is not None:
+        origin = f"{lat},{lng}"
+        waypoints = [f"{p['lat']},{p['lng']}" for p in selected[:-1]]
+    else:
+        origin = f"{selected[0]['lat']},{selected[0]['lng']}"
+        waypoints = [f"{p['lat']},{p['lng']}" for p in selected[1:-1]]
     destination = f"{selected[-1]['lat']},{selected[-1]['lng']}"
-    waypoints = [f"{p['lat']},{p['lng']}" for p in selected[1:-1]]
 
     try:
         directions = gmaps.directions(
@@ -397,8 +436,16 @@ async def generate_quest(
     legs = route.get("legs", [])
     polyline = route.get("overview_polyline", {}).get("points", "")
 
-    ordered = [selected[0]] + [selected[i+1] for i in waypoint_order] + [selected[-1]]
-    place_names = ", ".join([p["name"] for p in ordered])
+    if lat is not None and lng is not None:
+        ordered_waypoints = [selected[i] for i in waypoint_order]
+        ordered = (
+            [{"name": "Your Location", "type": "start", "lat": float(lat), "lng": float(lng), "tags": []}]
+            + ordered_waypoints
+            + [selected[-1]]
+        )
+    else:
+        ordered = [selected[0]] + [selected[i+1] for i in waypoint_order] + [selected[-1]]
+    place_names = ", ".join([p["name"] for p in ordered if p.get("type") != "start"])
 
     if openai.api_key:
         prompt = (
@@ -460,7 +507,10 @@ async def generate_quest(
     save_quest_to_firestore(hash_key, quest_obj)
     if user_id:
         await increment_daily_usage(user_id)
-    return {"quest": quest_obj}
+    result = {"quest": quest_obj}
+    if fallback_city:
+        result["fallbackCity"] = fallback_city
+    return result
 
 
 
@@ -963,7 +1013,9 @@ async def reroll_quest(payload: dict = Body(...)):
     time_limit = payload.get("time_limit", 60)
     token = payload.get("token", "")
     # Reuse generate_quest logic
-    return await generate_quest(city=city, moods=moods, time_limit=time_limit, token=token)
+    lat = payload.get("lat")
+    lng = payload.get("lng")
+    return await generate_quest(city=city, moods=moods, time_limit=time_limit, token=token, lat=lat, lng=lng)
 
 
 @app.post("/get-directions")

--- a/firestore.rules
+++ b/firestore.rules
@@ -48,6 +48,17 @@ service cloud.firestore {
       allow read, update, delete: if request.auth != null && request.auth.uid in resource.data.members && !isBanned();
     }
 
+    // ===== Communities =====
+    match /communities/{communityId} {
+      allow read: if true;
+      allow write: if request.auth != null && !isBanned();
+    }
+
+    // ===== Postcards =====
+    match /postcards/{userId}/{docId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId && !isBanned();
+    }
+
     // ===== Admin Config =====
     match /config/admins {
       allow read, write: if isAdmin();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,7 +17,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WanderQuest</title>
+    <title>Roamio</title>
 
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -24,7 +24,7 @@ const Header = () => {
   return (
     <header className="flex items-center justify-between px-6 py-4 border-b border-[#e6f4ef] bg-[#f8fcf8]">
       <Link to="/" className="text-xl font-bold text-[#0e1b0e]">
-        WanderQuest
+        Roamio
       </Link>
       <nav className="flex gap-4">
         <Link to="/home" className={linkClass("/home")}>Home</Link>

--- a/frontend/src/components/QuestHome.jsx
+++ b/frontend/src/components/QuestHome.jsx
@@ -37,6 +37,8 @@ const QuestHome = () => {
   const [city, setCity] = useState("");
   const [mood, setMood] = useState([]);
   const [timeLimit, setTimeLimit] = useState(90);
+  const [coords, setCoords] = useState(null);
+  const [gpsMsg, setGpsMsg] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [questResult, setQuestResult] = useState(null);
@@ -111,6 +113,24 @@ const QuestHome = () => {
     }
   };
 
+  const requestGps = () => {
+    if (!navigator.geolocation) {
+      setGpsMsg("Geolocation not supported");
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setCoords({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+        setGpsMsg("");
+      },
+      (err) => {
+        console.error("Geolocation error", err);
+        setCoords(null);
+        setGpsMsg("Location not shared — routing may be less accurate");
+      }
+    );
+  };
+
   const handleGenerate = async () => {
     setError("");
     setQuestResult(null);
@@ -128,11 +148,23 @@ const QuestHome = () => {
     setLoading(true);
     try {
       const token = await user.getIdToken();
-      const result = await generateQuest(city, mood, Number(timeLimit), token, user.uid);
+      const result = await generateQuest(
+        city,
+        mood,
+        Number(timeLimit),
+        token,
+        user.uid,
+        coords
+      );
       if (result.error) {
         console.error('❌ API error:', result);
         setError(result.error || 'Something went wrong generating your quest.');
         return;
+      }
+      if (result.fallbackCity) {
+        alert(
+          `That location isn\u2019t supported yet. Showing results near ${result.fallbackCity} instead.`
+        );
       }
       setQuestResult(result);
     } catch (err) {
@@ -211,6 +243,14 @@ const QuestHome = () => {
               onChange={(e) => setCity(e.target.value)}
               className="w-full px-4 py-2 border border-[#d0e7d0] rounded-lg focus:outline-none"
             />
+            <button
+              type="button"
+              onClick={requestGps}
+              className="text-sm underline text-blue-600"
+            >
+              {coords ? 'Location Set ✓' : 'Use My Location'}
+            </button>
+            {gpsMsg && <p className="text-xs text-red-600">{gpsMsg}</p>}
 
             <div className="flex flex-wrap gap-2">
               {moodOptions.map((option) => (
@@ -228,12 +268,18 @@ const QuestHome = () => {
               ))}
             </div>
 
-            <input
-              type="number"
-              value={String(timeLimit ?? "")}
-              onChange={(e) => setTimeLimit(Number(e.target.value) || 0)}
-              className="w-full px-4 py-2 border border-[#d0e7d0] rounded-lg focus:outline-none"
-            />
+            <label className="block text-sm font-medium text-[#0e1b0e]">
+              Time Limit: {timeLimit} minutes
+              <input
+                type="range"
+                min="30"
+                max="180"
+                step="15"
+                value={timeLimit}
+                onChange={(e) => setTimeLimit(Number(e.target.value))}
+                className="w-full mt-1"
+              />
+            </label>
 
             <button
               onClick={handleGenerate}

--- a/frontend/src/components/QuestLivePage.jsx
+++ b/frontend/src/components/QuestLivePage.jsx
@@ -234,6 +234,9 @@ export default function QuestLivePage() {
         .map((p) => `${p.lat},${p.lng}`)
         .join('|');
 
+      console.log('Waypoints', waypoints);
+      console.log('Remaining stops', remaining);
+
       const url = `https://maps.googleapis.com/maps/api/directions/json?origin=${origin}&destination=${destination}&mode=walking` +
         (waypoints ? `&waypoints=${waypoints}` : '') +
         `&key=${key}`;
@@ -246,6 +249,7 @@ export default function QuestLivePage() {
         const sec = legs.reduce((s, l) => s + (l.duration?.value || 0), 0);
         const mins = Math.round(sec / 60);
         setEtaText(`${mins} min`);
+        console.log('ETA legs', legs.map((l) => l.duration?.text));
         const poly = data?.routes?.[0]?.overview_polyline?.points;
         if (poly) {
           const decoded = decode(poly).map(([lat, lng]) => ({ lat, lng }));

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -7,7 +7,7 @@ const BASE_URL = import.meta.env.VITE_BACKEND_URL || "http://localhost:8080";
  * @param {number} timeLimit - Time limit in minutes
  * @param {string} token - Firebase user token for auth
  */
-export async function generateQuest(city, mood, timeLimit, token, userId) {
+export async function generateQuest(city, mood, timeLimit, token, userId, coords) {
   if (!city || !Array.isArray(mood) || mood.length === 0 || typeof timeLimit !== 'number') {
     throw new Error("Invalid input: city, mood[], and numeric timeLimit are required.");
   }
@@ -25,6 +25,8 @@ export async function generateQuest(city, mood, timeLimit, token, userId) {
       time_limit: timeLimit,
       token,
       user_id: userId,
+      lat: coords?.lat,
+      lng: coords?.lng,
     }),
   });
 

--- a/roamio-mobile/App.js
+++ b/roamio-mobile/App.js
@@ -1,0 +1,31 @@
+import React, { useEffect, useState } from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import MainNavigator from './navigation/MainNavigator';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from './firebase';
+
+export default function App() {
+  const [initializing, setInitializing] = useState(true);
+  const [user, setUser] = useState(null);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      if (initializing) setInitializing(false);
+    });
+    return unsubscribe;
+  }, [initializing]);
+
+  if (initializing) {
+    return null; // could show splash screen
+  }
+
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <NavigationContainer>
+        <MainNavigator user={user} />
+      </NavigationContainer>
+    </GestureHandlerRootView>
+  );
+}

--- a/roamio-mobile/app.json
+++ b/roamio-mobile/app.json
@@ -1,0 +1,21 @@
+{
+  "expo": {
+    "name": "Roamio",
+    "slug": "roamio",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "jsEngine": "hermes",
+    "sdkVersion": "49.0.0",
+    "platforms": ["ios", "android", "web"],
+    "assetBundlePatterns": ["**/*"],
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "adaptiveIcon": {
+        "foregroundImage": "./assets/icon.png",
+        "backgroundColor": "#FFFFFF"
+      }
+    }
+  }
+}

--- a/roamio-mobile/babel.config.js
+++ b/roamio-mobile/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['nativewind/babel'],
+  };
+};

--- a/roamio-mobile/components/SharedHeader.jsx
+++ b/roamio-mobile/components/SharedHeader.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function SharedHeader({ title }) {
+  return (
+    <View className="w-full py-4 bg-blue-500 items-center">
+      <Text className="text-white text-xl font-bold">{title}</Text>
+    </View>
+  );
+}

--- a/roamio-mobile/firebase.js
+++ b/roamio-mobile/firebase.js
@@ -1,0 +1,32 @@
+// Firebase initialization for React Native
+import { initializeApp } from 'firebase/app';
+import {
+  getAuth,
+  GoogleAuthProvider,
+} from 'firebase/auth';
+import {
+  getFirestore,
+  initializeFirestore,
+  persistentLocalCache,
+  persistentSingleTabManager,
+} from 'firebase/firestore';
+
+// Values are pulled from native config via process.env or expo-config
+const firebaseConfig = {
+  apiKey: process.env.EXPO_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.EXPO_PUBLIC_FIREBASE_APP_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+const db = initializeFirestore(app, {
+  experimentalForceLongPolling: true,
+  localCache: persistentLocalCache({ tabManager: persistentSingleTabManager() }),
+});
+const auth = getAuth(app);
+const provider = new GoogleAuthProvider();
+
+export { app, db, auth, provider };

--- a/roamio-mobile/navigation/MainNavigator.js
+++ b/roamio-mobile/navigation/MainNavigator.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import LoginScreen from '../screens/LoginScreen';
+import HomeScreen from '../screens/HomeScreen';
+import QuestLiveScreen from '../screens/QuestLiveScreen';
+import ProfileScreen from '../screens/ProfileScreen';
+import SettingsScreen from '../screens/SettingsScreen';
+
+const Stack = createNativeStackNavigator();
+
+export default function MainNavigator({ user }) {
+  return (
+    <Stack.Navigator>
+      {user ? (
+        <>
+          <Stack.Screen name="Home" component={HomeScreen} options={{ headerShown: false }} />
+          <Stack.Screen name="QuestLive" component={QuestLiveScreen} options={{ title: 'Quest' }} />
+          <Stack.Screen name="Profile" component={ProfileScreen} />
+          <Stack.Screen name="Settings" component={SettingsScreen} />
+        </>
+      ) : (
+        <Stack.Screen name="Login" component={LoginScreen} options={{ headerShown: false }} />
+      )}
+    </Stack.Navigator>
+  );
+}

--- a/roamio-mobile/package.json
+++ b/roamio-mobile/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "roamio-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "expo-auth-session": "~4.0.3",
+    "expo-location": "~15.1.1",
+    "firebase": "^10.7.0",
+    "nativewind": "^2.0.11",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "react-native-gesture-handler": "~2.12.0",
+    "react-native-maps": "1.8.1",
+    "react-native-reanimated": "~3.3.0",
+    "react-native-safe-area-context": "4.7.1",
+    "react-native-screens": "^3.20.0",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12"
+  }
+}

--- a/roamio-mobile/screens/HomeScreen.jsx
+++ b/roamio-mobile/screens/HomeScreen.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { View, Text, Button } from 'react-native';
+import * as Location from 'expo-location';
+import SharedHeader from '../components/SharedHeader';
+
+export default function HomeScreen({ navigation }) {
+  const [location, setLocation] = useState(null);
+  const [statusMsg, setStatusMsg] = useState('');
+
+  const requestLocation = async () => {
+    const { status } = await Location.requestForegroundPermissionsAsync();
+    if (status !== 'granted') {
+      setStatusMsg('Permission denied');
+      return;
+    }
+    const loc = await Location.getCurrentPositionAsync({});
+    setLocation(loc.coords);
+  };
+
+  return (
+    <View className="flex-1 items-center justify-center">
+      <SharedHeader title="Home" />
+      <Text className="text-lg mb-2">Welcome to Roamio</Text>
+      <Button title="Use GPS" onPress={requestLocation} />
+      {statusMsg ? <Text>{statusMsg}</Text> : null}
+      {location && (
+        <Text className="mt-2">Lat: {location.latitude}, Lng: {location.longitude}</Text>
+      )}
+      <Button title="Generate Quest" className="mt-4" onPress={() => navigation.navigate('QuestLive')} />
+    </View>
+  );
+}

--- a/roamio-mobile/screens/LoginScreen.jsx
+++ b/roamio-mobile/screens/LoginScreen.jsx
@@ -1,0 +1,38 @@
+import React, { useEffect } from 'react';
+import { View, Text, Button } from 'react-native';
+import * as WebBrowser from 'expo-web-browser';
+import * as Google from 'expo-auth-session/providers/google';
+import { makeRedirectUri } from 'expo-auth-session';
+import { signInWithCredential, GoogleAuthProvider } from 'firebase/auth';
+import { auth } from '../firebase';
+
+WebBrowser.maybeCompleteAuthSession();
+
+export default function LoginScreen({ navigation }) {
+  const [request, response, promptAsync] = Google.useAuthRequest({
+    expoClientId: process.env.EXPO_PUBLIC_GOOGLE_EXPO_CLIENT_ID,
+    iosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID,
+    androidClientId: process.env.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID,
+    webClientId: process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID,
+    redirectUri: makeRedirectUri({ useProxy: true }),
+  });
+
+  useEffect(() => {
+    if (response?.type === 'success') {
+      const { id_token, access_token } = response.params;
+      const credential = GoogleAuthProvider.credential(id_token, access_token);
+      signInWithCredential(auth, credential).catch((err) => console.error(err));
+    }
+  }, [response]);
+
+  return (
+    <View className="flex-1 items-center justify-center bg-white">
+      <Text className="text-2xl mb-4">Roamio</Text>
+      <Button
+        title="Sign in with Google"
+        disabled={!request}
+        onPress={() => promptAsync({ useProxy: true })}
+      />
+    </View>
+  );
+}

--- a/roamio-mobile/screens/ProfileScreen.jsx
+++ b/roamio-mobile/screens/ProfileScreen.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import SharedHeader from '../components/SharedHeader';
+
+export default function ProfileScreen() {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <SharedHeader title="Profile" />
+      <Text>Completed Quests</Text>
+      {/* Quest history grid/list placeholder */}
+    </View>
+  );
+}

--- a/roamio-mobile/screens/QuestLiveScreen.jsx
+++ b/roamio-mobile/screens/QuestLiveScreen.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+import SharedHeader from '../components/SharedHeader';
+
+export default function QuestLiveScreen() {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <SharedHeader title="Quest" />
+      <Text>Quest in Progress</Text>
+      {/* Map and quest stops will go here */}
+    </View>
+  );
+}

--- a/roamio-mobile/screens/SettingsScreen.jsx
+++ b/roamio-mobile/screens/SettingsScreen.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, Button } from 'react-native';
+import { signOut } from 'firebase/auth';
+import { auth } from '../firebase';
+import SharedHeader from '../components/SharedHeader';
+
+export default function SettingsScreen() {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <SharedHeader title="Settings" />
+      <Button title="Logout" onPress={() => signOut(auth)} />
+      <Text className="mt-4">Notifications (coming soon)</Text>
+    </View>
+  );
+}

--- a/roamio-mobile/tailwind.config.js
+++ b/roamio-mobile/tailwind.config.js
@@ -1,0 +1,13 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './App.js',
+    './screens/**/*.{js,jsx,ts,tsx}',
+    './components/**/*.{js,jsx,ts,tsx}',
+    './navigation/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- adjust quest time slider to 30–180 minutes
- alert when backend falls back to a nearby city
- prepend GPS coordinates to route when available
- provide fallback city logic in backend
- add React Native mobile scaffold

## Testing
- `python -m py_compile backend/main.py`
- `node firestoreRules.test.js` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_6881a15ed3b0832188b419ec204752de