### PR TITLE
Add custom quest builder with premium gating

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -11,11 +11,13 @@ import openai
 import certifi
 from google.cloud import firestore_v1, storage
 from google.oauth2 import service_account
-from google.auth.transport.requests import AuthorizedSession
+from google.auth.transport.requests import AuthorizedSession, Request as GoogleRequest
+from google.oauth2 import id_token
 
 
 from dotenv import load_dotenv
 from emotion_utils import generate_filtered_quest_payload
+from stripe_utils import create_subscription_session, verify_webhook
 
 # === Load .env variables (if running locally) ===
 load_dotenv()
@@ -254,6 +256,13 @@ def fill_template(template: str, city: str, mood: str, places: list[dict]) -> st
 
 app = FastAPI()
 
+# Manual fallbacks for vague regions
+CITY_FALLBACK_MAP = {
+    "hudson valley": "New York",
+    "catskills": "Albany",
+    "poconos": "Philadelphia",
+}
+
 # ✅ Replace this with your actual frontend deployed domain
 allowed_origins = [
     "http://localhost:5173",  # Vite dev server (local)
@@ -282,6 +291,8 @@ async def generate_quest(
     time_limit: int = Body(...),
     token: str = Body(...),
     user_id: str | None = Body(None),
+    lat: float | None = Body(None),
+    lng: float | None = Body(None),
 ):
     """Generate a quest using tag-based filtering and optional GPT text."""
     if not city or not moods:
@@ -298,11 +309,98 @@ async def generate_quest(
             return JSONResponse(status_code=403, content={"error": "Daily quest limit reached"})
 
     try:
-        geocode = gmaps.geocode(city)
-        city_location = geocode[0]["geometry"]["location"]
+        if lat is not None and lng is not None:
+            city_location = {"lat": float(lat), "lng": float(lng)}
+        else:
+            geocode = gmaps.geocode(city)
+            city_location = geocode[0]["geometry"]["location"]
     except Exception as e:
         print(f"Geocoding error: {e}")
         return {"error": "Failed to locate city center."}
+
+
+    attempts = 0
+    fallback_city = None
+    selected = []
+    while attempts < 2:
+        try:
+            response = gmaps.places_nearby(
+                location=(city_location["lat"], city_location["lng"]),
+                radius=2000,
+                type="tourist_attraction",
+            )
+            places_results = response.get("results", [])
+        except Exception as e:
+            print(f"Places API error: {e}")
+            return {"error": "Failed to fetch places"}
+
+        candidates = []
+        for place in places_results:
+            try:
+                name = place.get("name")
+                if not name or is_chain(name):
+                    continue
+                pid = place.get("place_id")
+                cached_place = get_cached_place(pid) if pid else None
+                details = None
+                if not cached_place and pid:
+                    try:
+                        details = gmaps.place(pid)
+                    except Exception:
+                        details = None
+                tags = (
+                    cached_place.get("tags") if cached_place else compute_place_tags(place, details)
+                )
+                if not cached_place and pid:
+                    save_place_to_cache(pid, {"tags": tags, "name": name})
+                if preferred:
+                    overlap = len(set(tags) & set(preferred))
+                else:
+                    overlap = 1
+                if overlap <= 0:
+                    continue
+                loc = place["geometry"]["location"]
+                typ = place.get("types", ["Unknown"])[0]
+                candidates.append({
+                    "name": name,
+                    "type": typ,
+                    "lat": float(loc["lat"]),
+                    "lng": float(loc["lng"]),
+                    "tags": tags,
+                    "score": overlap,
+                    "rating": place.get("rating", 0),
+                })
+            except Exception as e:
+                print("Skipping place", e)
+        candidates.sort(key=lambda x: (x["score"], x["rating"]), reverse=True)
+
+        selected = []
+        seen_types = set()
+        for c in candidates:
+            if c["type"] in seen_types:
+                continue
+            selected.append(c)
+            seen_types.add(c["type"])
+            if len(selected) >= 5:
+                break
+
+        if len(selected) >= 3:
+            break
+
+        fallback_city = CITY_FALLBACK_MAP.get(city.lower())
+        if not fallback_city:
+            break
+        attempts += 1
+        try:
+            geo = gmaps.geocode(fallback_city)
+            city_location = geo[0]["geometry"]["location"]
+            city = fallback_city
+        except Exception as e:
+            print("Fallback geocode error", e)
+            break
+
+    if len(selected) < 3:
+        return {"error": "Not enough matching places"}
 
     loc_hash = f"{city_location['lat']:.2f}_{city_location['lng']:.2f}"
     tag_combo = "-".join(sorted(preferred)) if preferred else "none"
@@ -310,75 +408,18 @@ async def generate_quest(
     cached = get_cached_quest(hash_key)
     if cached:
         print("Using cached quest")
-        return {"quest": cached}
+        result = {"quest": cached}
+        if fallback_city:
+            result["fallbackCity"] = fallback_city
+        return result
 
-    try:
-        response = gmaps.places_nearby(
-            location=(city_location["lat"], city_location["lng"]),
-            radius=2000,
-            type="tourist_attraction",
-        )
-        places_results = response.get("results", [])
-    except Exception as e:
-        print(f"Places API error: {e}")
-        return {"error": "Failed to fetch places"}
-
-    candidates = []
-    for place in places_results:
-        try:
-            name = place.get("name")
-            if not name or is_chain(name):
-                continue
-            pid = place.get("place_id")
-            cached_place = get_cached_place(pid) if pid else None
-            details = None
-            if not cached_place and pid:
-                try:
-                    details = gmaps.place(pid)
-                except Exception:
-                    details = None
-            tags = (
-                cached_place.get("tags") if cached_place else compute_place_tags(place, details)
-            )
-            if not cached_place and pid:
-                save_place_to_cache(pid, {"tags": tags, "name": name})
-            if preferred:
-                overlap = len(set(tags) & set(preferred))
-            else:
-                overlap = 1
-            if overlap <= 0:
-                continue
-            loc = place["geometry"]["location"]
-            typ = place.get("types", ["Unknown"])[0]
-            candidates.append({
-                "name": name,
-                "type": typ,
-                "lat": float(loc["lat"]),
-                "lng": float(loc["lng"]),
-                "tags": tags,
-                "score": overlap,
-                "rating": place.get("rating", 0),
-            })
-        except Exception as e:
-            print("Skipping place", e)
-    candidates.sort(key=lambda x: (x["score"], x["rating"]), reverse=True)
-
-    selected = []
-    seen_types = set()
-    for c in candidates:
-        if c["type"] in seen_types:
-            continue
-        selected.append(c)
-        seen_types.add(c["type"])
-        if len(selected) >= 5:
-            break
-
-    if len(selected) < 3:
-        return {"error": "Not enough matching places"}
-
-    origin = f"{selected[0]['lat']},{selected[0]['lng']}"
+    if lat is not None and lng is not None:
+        origin = f"{lat},{lng}"
+        waypoints = [f"{p['lat']},{p['lng']}" for p in selected[:-1]]
+    else:
+        origin = f"{selected[0]['lat']},{selected[0]['lng']}"
+        waypoints = [f"{p['lat']},{p['lng']}" for p in selected[1:-1]]
     destination = f"{selected[-1]['lat']},{selected[-1]['lng']}"
-    waypoints = [f"{p['lat']},{p['lng']}" for p in selected[1:-1]]
 
     try:
         directions = gmaps.directions(
@@ -397,8 +438,16 @@ async def generate_quest(
     legs = route.get("legs", [])
     polyline = route.get("overview_polyline", {}).get("points", "")
 
-    ordered = [selected[0]] + [selected[i+1] for i in waypoint_order] + [selected[-1]]
-    place_names = ", ".join([p["name"] for p in ordered])
+    if lat is not None and lng is not None:
+        ordered_waypoints = [selected[i] for i in waypoint_order]
+        ordered = (
+            [{"name": "Your Location", "type": "start", "lat": float(lat), "lng": float(lng), "tags": []}]
+            + ordered_waypoints
+            + [selected[-1]]
+        )
+    else:
+        ordered = [selected[0]] + [selected[i+1] for i in waypoint_order] + [selected[-1]]
+    place_names = ", ".join([p["name"] for p in ordered if p.get("type") != "start"])
 
     if openai.api_key:
         prompt = (
@@ -460,7 +509,10 @@ async def generate_quest(
     save_quest_to_firestore(hash_key, quest_obj)
     if user_id:
         await increment_daily_usage(user_id)
-    return {"quest": quest_obj}
+    result = {"quest": quest_obj}
+    if fallback_city:
+        result["fallbackCity"] = fallback_city
+    return result
 
 
 
@@ -521,6 +573,28 @@ async def check_premium(user_id: str) -> bool:
         fields = _decode_document(resp.json())
         return fields.get("premium") is True
     return False
+
+
+async def _verify_token(auth_header: str | None) -> str | None:
+    """Return user ID if bearer token is valid."""
+    if not auth_header or not auth_header.startswith("Bearer "):
+        return None
+    token = auth_header.split(" ", 1)[1]
+    try:
+        info = id_token.verify_oauth2_token(token, GoogleRequest())
+        return info.get("uid") or info.get("sub")
+    except Exception as e:
+        print("Token verify failed", e)
+        return None
+
+
+async def log_admin_event(event: str, payload: dict):
+    """Write a simple event document to admin_logs."""
+    doc_id = hashlib.sha1(f"{event}-{datetime.utcnow()}".encode()).hexdigest()[:12]
+    project_id = creds.project_id
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/admin_logs/{doc_id}"
+    body = {"fields": _encode_fields({"event": event, "payload": payload, "created": datetime.utcnow().isoformat()})}
+    await asyncio.to_thread(rest_session.patch, url, json=body)
 
 
 async def get_daily_usage(user_id: str) -> int:
@@ -963,7 +1037,9 @@ async def reroll_quest(payload: dict = Body(...)):
     time_limit = payload.get("time_limit", 60)
     token = payload.get("token", "")
     # Reuse generate_quest logic
-    return await generate_quest(city=city, moods=moods, time_limit=time_limit, token=token)
+    lat = payload.get("lat")
+    lng = payload.get("lng")
+    return await generate_quest(city=city, moods=moods, time_limit=time_limit, token=token, lat=lat, lng=lng)
 
 
 @app.post("/get-directions")
@@ -1354,17 +1430,7 @@ async def create_checkout_session(payload: dict = Body(...)):
     stripe_key = os.getenv("STRIPE_SECRET_KEY")
     if stripe_key:
         try:
-            import stripe
-            stripe.api_key = stripe_key
-            session = await asyncio.to_thread(
-                stripe.checkout.Session.create,
-                payment_method_types=["card"],
-                mode="payment",
-                line_items=[{"price": os.getenv("STRIPE_PRICE_ID", "price_123"), "quantity": 1}],
-                customer_email=email,
-                success_url=success,
-                cancel_url=cancel,
-            )
+            session = await create_subscription_session(user_id, email, success, cancel)
             return {"url": session.url}
         except Exception as e:
             print("Stripe error", e)
@@ -1403,6 +1469,52 @@ async def validate_premium(user_id: str, session_id: str | None = Query(None)):
             await asyncio.to_thread(rest_session.patch, user_url, json=body)
 
     return {"premium": premium}
+
+
+@app.post("/validate-premium")
+async def validate_premium_token(request: Request):
+    """Return premium status for the authenticated user."""
+    uid = await _verify_token(request.headers.get("Authorization"))
+    if not uid:
+        return JSONResponse(status_code=401, content={"error": "unauthorized"})
+    project_id = creds.project_id
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/users/{uid}"
+    resp = await asyncio.to_thread(rest_session.get, url)
+    fields = _decode_document(resp.json()) if resp.status_code == 200 else {}
+    premium = fields.get("premium") is True
+    return {"isPremium": premium}
+
+
+@app.post("/stripe-webhook")
+async def stripe_webhook(request: Request):
+    """Handle Stripe webhook events."""
+    stripe_key = os.getenv("STRIPE_SECRET_KEY")
+    webhook_secret = os.getenv("STRIPE_WEBHOOK_SECRET")
+    if not stripe_key or not webhook_secret:
+        return {"status": "disabled"}
+
+    payload = await request.body()
+    sig = request.headers.get("stripe-signature", "")
+    try:
+        event = verify_webhook(payload, sig)
+    except Exception as e:
+        print("Webhook verify error", e)
+        return JSONResponse(status_code=400, content={"error": "invalid"})
+
+    if event["type"] == "checkout.session.completed":
+        session = event["data"]["object"]
+        uid = session.get("metadata", {}).get("uid") or session.get("client_reference_id")
+        if uid:
+            project_id = creds.project_id
+            url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/users/{uid}"
+            resp = await asyncio.to_thread(rest_session.get, url)
+            fields = _decode_document(resp.json()) if resp.status_code == 200 else {}
+            fields["premium"] = True
+            body = {"fields": _encode_fields(fields)}
+            await asyncio.to_thread(rest_session.patch, url, json=body)
+            await log_admin_event("stripe_checkout", {"uid": uid, "session": session.get("id")})
+
+    return {"received": True}
 
 
 @app.post("/update-active-quest")

--- a/backend/stripe_utils.py
+++ b/backend/stripe_utils.py
@@ -1,0 +1,26 @@
+import os
+import stripe
+import asyncio
+
+stripe.api_key = os.getenv("STRIPE_SECRET_KEY", "")
+
+async def create_subscription_session(user_id: str, email: str, success: str, cancel: str):
+    """Create a Stripe Checkout session for subscriptions."""
+    return await asyncio.to_thread(
+        stripe.checkout.Session.create,
+        payment_method_types=["card"],
+        mode="subscription",
+        line_items=[{"price": os.getenv("STRIPE_PRICE_ID", "price_123"), "quantity": 1}],
+        customer_email=email,
+        client_reference_id=user_id,
+        metadata={"uid": user_id},
+        success_url=success,
+        cancel_url=cancel,
+    )
+
+
+def verify_webhook(payload: bytes, sig: str):
+    secret = os.getenv("STRIPE_WEBHOOK_SECRET")
+    if not secret:
+        raise ValueError("Missing webhook secret")
+    return stripe.Webhook.construct_event(payload, sig, secret)

--- a/firestore.rules
+++ b/firestore.rules
@@ -48,6 +48,17 @@ service cloud.firestore {
       allow read, update, delete: if request.auth != null && request.auth.uid in resource.data.members && !isBanned();
     }
 
+    // ===== Communities =====
+    match /communities/{communityId} {
+      allow read: if true;
+      allow write: if request.auth != null && !isBanned();
+    }
+
+    // ===== Postcards =====
+    match /postcards/{userId}/{docId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId && !isBanned();
+    }
+
     // ===== Admin Config =====
     match /config/admins {
       allow read, write: if isAdmin();

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -17,7 +17,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>WanderQuest</title>
+    <title>Roamio</title>
 
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -14,7 +14,7 @@ import Header from "./components/Header";
 import Footer from "./components/Footer";
 import QuestRoute from "./components/QuestRoute";
 import QuestLivePage from "./components/QuestLivePage";
-import QuestPlusPage from "./components/QuestPlusPage";
+import Pricing from "./pages/Pricing";
 import PaymentSuccess from "./components/PaymentSuccess";
 import PaymentFailed from "./components/PaymentFailed";
 import CommunityFeed from "./components/CommunityFeed";
@@ -75,7 +75,8 @@ function App() {
         <Route path="/community/:id" element={<CommunityPage />} />
         <Route path="/explore" element={<Explore />} />
         <Route path="/admin" element={<AdminDashboard />} />
-        <Route path="/quest-plus" element={<QuestPlusPage />} />
+        <Route path="/quest-plus" element={<Pricing />} />
+        <Route path="/pricing" element={<Pricing />} />
         <Route path="/custom" element={<CustomQuestBuilder />} />
         <Route path="/q/:questId" element={<PublicQuestPage />} />
         <Route path="/tag-editor/:questId" element={<TagEditor />} />

--- a/frontend/src/components/CustomQuestBuilder.jsx
+++ b/frontend/src/components/CustomQuestBuilder.jsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getAuth, onAuthStateChanged } from 'firebase/auth';
 import { createCustomQuest, createGroupQuest, validatePremium, publishCustomQuest } from '../lib/api';
+import PremiumGuard from './PremiumGuard';
 
 const moodOptions = [
   'romantic',
@@ -41,8 +42,8 @@ export default function CustomQuestBuilder() {
       setUser(u);
       if (u) {
         try {
-          const r = await validatePremium(u.uid);
-          setPremium(!!r.premium);
+          const r = await validatePremium();
+          setPremium(!!r.isPremium);
         } catch (err) {
           console.error('premium check failed', err);
           setPremium(false);
@@ -94,7 +95,7 @@ export default function CustomQuestBuilder() {
 
   const handleStart = async () => {
     if (!user) return alert('Login required');
-    if (!premium) return navigate('/quest-plus');
+    if (!premium) return navigate('/pricing');
     if (locations.some((l) => !l.placeId)) return alert('Select valid locations');
     try {
       console.log('Submitting custom quest with:', { title, moods, locationList: locations });
@@ -150,7 +151,7 @@ export default function CustomQuestBuilder() {
 
   const handlePublish = async () => {
     if (!user) return alert('Login required');
-    if (!premium) return navigate('/quest-plus');
+    if (!premium) return navigate('/pricing');
     try {
       console.log('Submitting custom quest with:', { title, moods, locationList: locations });
       const res = await createCustomQuest({
@@ -177,6 +178,7 @@ export default function CustomQuestBuilder() {
   };
 
   return (
+    <PremiumGuard>
     <div className="min-h-screen bg-[#f8fcf8] px-6 py-8 text-[#0e1b0e] font-sans">
       <h1 className="text-2xl font-bold mb-6 text-center">Build a Custom Quest</h1>
 
@@ -311,7 +313,7 @@ export default function CustomQuestBuilder() {
         {!premium && (
           <p className="text-center text-sm">
             Custom quests are a Quest+ feature.{' '}
-            <a href="/quest-plus" className="text-blue-600 underline">
+            <a href="/pricing" className="text-blue-600 underline">
               Upgrade to Quest+
             </a>
           </p>
@@ -319,6 +321,7 @@ export default function CustomQuestBuilder() {
         {error && <p className="text-red-600 text-sm text-center">{error}</p>}
       </div>
     </div>
+    </PremiumGuard>
   );
 }
 

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -24,7 +24,7 @@ const Header = () => {
   return (
     <header className="flex items-center justify-between px-6 py-4 border-b border-[#e6f4ef] bg-[#f8fcf8]">
       <Link to="/" className="text-xl font-bold text-[#0e1b0e]">
-        WanderQuest
+        Roamio
       </Link>
       <nav className="flex gap-4">
         <Link to="/home" className={linkClass("/home")}>Home</Link>
@@ -35,7 +35,7 @@ const Header = () => {
         {user && (
           <Link to="/custom" className={linkClass("/custom")}>➕ Custom Quest</Link>
         )}
-        <Link to="/quest-plus" className={linkClass("/quest-plus")}>Quest+</Link>
+        <Link to="/pricing" className={linkClass("/pricing")}>Quest+</Link>
         {isAdmin && (
           <Link to="/admin" className={linkClass("/admin")}>Admin</Link>
         )}

--- a/frontend/src/components/PremiumGuard.jsx
+++ b/frontend/src/components/PremiumGuard.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import { onAuthStateChanged, getAuth } from 'firebase/auth';
+import { validatePremium } from '../lib/api';
+
+export default function PremiumGuard({ children }) {
+  const [allowed, setAllowed] = useState(null);
+
+  useEffect(() => {
+    const auth = getAuth();
+    const unsub = onAuthStateChanged(auth, async (user) => {
+      if (!user) return setAllowed(false);
+      try {
+        const res = await validatePremium();
+        setAllowed(!!res.isPremium);
+      } catch (err) {
+        console.error('premium check failed', err);
+        setAllowed(false);
+      }
+    });
+    return () => unsub();
+  }, []);
+
+  if (allowed === null) {
+    return <p className="text-center py-10">Checking subscription...</p>;
+  }
+  if (!allowed) {
+    return (
+      <div className="text-center space-y-2 py-10">
+        <p>Quest+ membership required.</p>
+        <a href="/pricing" className="text-blue-600 underline">Upgrade to Quest+</a>
+      </div>
+    );
+  }
+  return <>{children}</>;
+}

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -16,8 +16,8 @@ const Profile = () => {
       setUser(u);
       if (u) {
         try {
-          const data = await validatePremium(u.uid);
-          setPremium(!!data.premium);
+          const data = await validatePremium();
+          setPremium(!!data.isPremium);
         } catch (err) {
           console.error('Failed to validate premium', err);
         }
@@ -79,7 +79,7 @@ const Profile = () => {
       ) : (
         <div className="text-center space-y-2">
           <p className="text-sm">Quest+ membership required to view your full postcard history.</p>
-          <a href="/quest-plus" className="text-blue-600 underline">Upgrade to Quest+</a>
+          <a href="/pricing" className="text-blue-600 underline">Upgrade to Quest+</a>
         </div>
       )}
       <div className="mt-8">

--- a/frontend/src/components/QuestHome.jsx
+++ b/frontend/src/components/QuestHome.jsx
@@ -37,6 +37,8 @@ const QuestHome = () => {
   const [city, setCity] = useState("");
   const [mood, setMood] = useState([]);
   const [timeLimit, setTimeLimit] = useState(90);
+  const [coords, setCoords] = useState(null);
+  const [gpsMsg, setGpsMsg] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [questResult, setQuestResult] = useState(null);
@@ -51,8 +53,8 @@ const QuestHome = () => {
       setUser(firebaseUser);
       if (firebaseUser) {
         try {
-          const res = await validatePremium(firebaseUser.uid);
-          setPremium(!!res.premium);
+          const res = await validatePremium();
+          setPremium(!!res.isPremium);
         } catch (err) {
           console.error('premium check failed', err);
         }
@@ -111,6 +113,24 @@ const QuestHome = () => {
     }
   };
 
+  const requestGps = () => {
+    if (!navigator.geolocation) {
+      setGpsMsg("Geolocation not supported");
+      return;
+    }
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setCoords({ lat: pos.coords.latitude, lng: pos.coords.longitude });
+        setGpsMsg("");
+      },
+      (err) => {
+        console.error("Geolocation error", err);
+        setCoords(null);
+        setGpsMsg("Location not shared — routing may be less accurate");
+      }
+    );
+  };
+
   const handleGenerate = async () => {
     setError("");
     setQuestResult(null);
@@ -128,11 +148,23 @@ const QuestHome = () => {
     setLoading(true);
     try {
       const token = await user.getIdToken();
-      const result = await generateQuest(city, mood, Number(timeLimit), token, user.uid);
+      const result = await generateQuest(
+        city,
+        mood,
+        Number(timeLimit),
+        token,
+        user.uid,
+        coords
+      );
       if (result.error) {
         console.error('❌ API error:', result);
         setError(result.error || 'Something went wrong generating your quest.');
         return;
+      }
+      if (result.fallbackCity) {
+        alert(
+          `That location isn\u2019t supported yet. Showing results near ${result.fallbackCity} instead.`
+        );
       }
       setQuestResult(result);
     } catch (err) {
@@ -145,7 +177,7 @@ const QuestHome = () => {
 
   const handleStartQuest = async () => {
     if (!premium) {
-      navigate('/quest-plus');
+      navigate('/pricing');
       return;
     }
     if (!questResult) return;
@@ -211,6 +243,14 @@ const QuestHome = () => {
               onChange={(e) => setCity(e.target.value)}
               className="w-full px-4 py-2 border border-[#d0e7d0] rounded-lg focus:outline-none"
             />
+            <button
+              type="button"
+              onClick={requestGps}
+              className="text-sm underline text-blue-600"
+            >
+              {coords ? 'Location Set ✓' : 'Use My Location'}
+            </button>
+            {gpsMsg && <p className="text-xs text-red-600">{gpsMsg}</p>}
 
             <div className="flex flex-wrap gap-2">
               {moodOptions.map((option) => (
@@ -228,12 +268,18 @@ const QuestHome = () => {
               ))}
             </div>
 
-            <input
-              type="number"
-              value={String(timeLimit ?? "")}
-              onChange={(e) => setTimeLimit(Number(e.target.value) || 0)}
-              className="w-full px-4 py-2 border border-[#d0e7d0] rounded-lg focus:outline-none"
-            />
+            <label className="block text-sm font-medium text-[#0e1b0e]">
+              Time Limit: {timeLimit} minutes
+              <input
+                type="range"
+                min="30"
+                max="180"
+                step="15"
+                value={timeLimit}
+                onChange={(e) => setTimeLimit(Number(e.target.value))}
+                className="w-full mt-1"
+              />
+            </label>
 
             <button
               onClick={handleGenerate}
@@ -277,7 +323,7 @@ const QuestHome = () => {
               {!premium && (
                 <p className="text-center text-xs mt-1">
                   Quest+ required to start quests.{' '}
-                  <a href="/quest-plus" className="text-blue-600 underline">Upgrade</a>
+                  <a href="/pricing" className="text-blue-600 underline">Upgrade</a>
                 </p>
               )}
               {resumeData && (

--- a/frontend/src/components/QuestLivePage.jsx
+++ b/frontend/src/components/QuestLivePage.jsx
@@ -234,6 +234,9 @@ export default function QuestLivePage() {
         .map((p) => `${p.lat},${p.lng}`)
         .join('|');
 
+      console.log('Waypoints', waypoints);
+      console.log('Remaining stops', remaining);
+
       const url = `https://maps.googleapis.com/maps/api/directions/json?origin=${origin}&destination=${destination}&mode=walking` +
         (waypoints ? `&waypoints=${waypoints}` : '') +
         `&key=${key}`;
@@ -246,6 +249,7 @@ export default function QuestLivePage() {
         const sec = legs.reduce((s, l) => s + (l.duration?.value || 0), 0);
         const mins = Math.round(sec / 60);
         setEtaText(`${mins} min`);
+        console.log('ETA legs', legs.map((l) => l.duration?.text));
         const poly = data?.routes?.[0]?.overview_polyline?.points;
         if (poly) {
           const decoded = decode(poly).map(([lat, lng]) => ({ lat, lng }));

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -1,4 +1,5 @@
 const BASE_URL = import.meta.env.VITE_BACKEND_URL || "http://localhost:8080";
+import { getAuth } from 'firebase/auth';
 
 /**
  * Fetches a generated quest from the backend
@@ -7,7 +8,7 @@ const BASE_URL = import.meta.env.VITE_BACKEND_URL || "http://localhost:8080";
  * @param {number} timeLimit - Time limit in minutes
  * @param {string} token - Firebase user token for auth
  */
-export async function generateQuest(city, mood, timeLimit, token, userId) {
+export async function generateQuest(city, mood, timeLimit, token, userId, coords) {
   if (!city || !Array.isArray(mood) || mood.length === 0 || typeof timeLimit !== 'number') {
     throw new Error("Invalid input: city, mood[], and numeric timeLimit are required.");
   }
@@ -25,6 +26,8 @@ export async function generateQuest(city, mood, timeLimit, token, userId) {
       time_limit: timeLimit,
       token,
       user_id: userId,
+      lat: coords?.lat,
+      lng: coords?.lng,
     }),
   });
 
@@ -64,12 +67,22 @@ export async function uploadPostcard(userId, questId, imageUrl) {
 }
 
 export async function validatePremium(userId, sessionId) {
-  const url = new URL(`${BASE_URL}/validate-premium/${userId}`);
-  if (sessionId) url.searchParams.set('session_id', sessionId);
-  const resp = await fetch(url.toString());
-  if (!resp.ok) {
-    throw new Error('Failed to validate premium');
+  if (sessionId && userId) {
+    const url = new URL(`${BASE_URL}/validate-premium/${userId}`);
+    url.searchParams.set('session_id', sessionId);
+    const resp = await fetch(url.toString());
+    if (!resp.ok) throw new Error('Failed to validate premium');
+    return resp.json();
   }
+  const auth = getAuth();
+  const user = auth.currentUser;
+  if (!user) return { isPremium: false };
+  const token = await user.getIdToken();
+  const resp = await fetch(`${BASE_URL}/validate-premium`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!resp.ok) throw new Error('Failed to validate premium');
   return resp.json();
 }
 

--- a/frontend/src/pages/Pricing.jsx
+++ b/frontend/src/pages/Pricing.jsx
@@ -1,0 +1,49 @@
+import React, { useState } from 'react';
+import { getAuth } from 'firebase/auth';
+import { createCheckoutSession } from '../lib/api';
+
+const features = [
+  'Unlimited quest generation',
+  'Custom quest builder',
+  'Group quest hosting',
+  'Full postcard history',
+];
+
+export default function Pricing() {
+  const [loading, setLoading] = useState(false);
+  const auth = getAuth();
+
+  const handleCheckout = async () => {
+    const user = auth.currentUser;
+    if (!user) return alert('Login required');
+    setLoading(true);
+    try {
+      const res = await createCheckoutSession(user.uid, user.email);
+      window.location.href = res.url;
+    } catch (err) {
+      console.error('checkout failed', err);
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex flex-col items-center justify-center bg-[#f8fcf8] px-6 py-10 text-center space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-[#0e1b0e] mb-2">Quest+ Membership</h1>
+        <p className="text-[#0e1b0e] mb-4">Unlock Roamio premium features for just $5/month.</p>
+        <ul className="text-left mb-4 list-disc list-inside space-y-1">
+          {features.map((f) => (
+            <li key={f}>{f}</li>
+          ))}
+        </ul>
+        <button
+          onClick={handleCheckout}
+          disabled={loading}
+          className="px-5 py-2 rounded-full bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {loading ? 'Redirecting...' : 'Upgrade Now'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/roamio-mobile/App.js
+++ b/roamio-mobile/App.js
@@ -1,0 +1,30 @@
+import React, { useContext } from 'react';
+import { NavigationContainer } from '@react-navigation/native';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import MainNavigator from './navigation/MainNavigator';
+import { AppProvider, AppContext } from './context/AppContext';
+import { ActivityIndicator, View } from 'react-native';
+
+function AppContent() {
+  const { loading } = useContext(AppContext);
+  if (loading) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+  return <MainNavigator />;
+}
+
+export default function App() {
+  return (
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <AppProvider>
+        <NavigationContainer>
+          <AppContent />
+        </NavigationContainer>
+      </AppProvider>
+    </GestureHandlerRootView>
+  );
+}

--- a/roamio-mobile/app.json
+++ b/roamio-mobile/app.json
@@ -1,0 +1,30 @@
+{
+  "expo": {
+    "name": "Roamio",
+    "slug": "roamio",
+    "version": "1.0.0",
+    "orientation": "portrait",
+    "jsEngine": "hermes",
+    "sdkVersion": "49.0.0",
+    "platforms": [
+      "ios",
+      "android",
+      "web"
+    ],
+    "assetBundlePatterns": [
+      "**/*"
+    ],
+    "ios": {
+      "supportsTablet": true
+    },
+    "android": {
+      "adaptiveIcon": {
+        "foregroundImage": "./assets/icon.png",
+        "backgroundColor": "#FFFFFF"
+      }
+    },
+    "extra": {
+      "backendUrl": "http://localhost:8080"
+    }
+  }
+}

--- a/roamio-mobile/babel.config.js
+++ b/roamio-mobile/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function(api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['nativewind/babel'],
+  };
+};

--- a/roamio-mobile/components/SharedHeader.jsx
+++ b/roamio-mobile/components/SharedHeader.jsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import { View, Text } from 'react-native';
+
+export default function SharedHeader({ title }) {
+  return (
+    <View className="w-full py-4 bg-blue-500 items-center">
+      <Text className="text-white text-xl font-bold">{title}</Text>
+    </View>
+  );
+}

--- a/roamio-mobile/context/AppContext.js
+++ b/roamio-mobile/context/AppContext.js
@@ -1,0 +1,66 @@
+import React, { createContext, useState, useEffect } from 'react';
+import { onAuthStateChanged } from 'firebase/auth';
+import { doc, getDoc } from 'firebase/firestore';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { auth, db } from '../firebase';
+import { registerForPushNotifications } from '../lib/notifications';
+import { toast } from '../lib/toast';
+
+export const AppContext = createContext();
+
+export function AppProvider({ children }) {
+  const [user, setUser] = useState(null);
+  const [quest, setQuest] = useState(null);
+  const [isPremium, setIsPremium] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (u) => {
+      setUser(u);
+      if (u) {
+        try {
+          const snap = await getDoc(doc(db, 'users', u.uid));
+          if (snap.exists()) {
+            setIsPremium(snap.data().premium === true);
+          }
+          await registerForPushNotifications();
+        } catch (err) {
+          console.log('Premium fetch error', err);
+        }
+        try {
+          const saved = await AsyncStorage.getItem('currentQuest');
+          if (saved) setQuest(JSON.parse(saved));
+        } catch (err) {
+          console.log('Quest load error', err);
+        }
+      } else {
+        setIsPremium(false);
+        setQuest(null);
+        await AsyncStorage.removeItem('currentQuest');
+      }
+      setLoading(false);
+    });
+    return unsubscribe;
+  }, []);
+
+  useEffect(() => {
+    async function persist() {
+      if (quest) {
+        try {
+          await AsyncStorage.setItem('currentQuest', JSON.stringify(quest));
+          toast('Quest cached for offline use');
+        } catch (err) {
+          console.log('Quest cache error', err);
+          toast('Failed to cache quest');
+        }
+      }
+    }
+    persist();
+  }, [quest]);
+
+  return (
+    <AppContext.Provider value={{ user, quest, setQuest, isPremium, loading }}>
+      {children}
+    </AppContext.Provider>
+  );
+}

--- a/roamio-mobile/firebase.js
+++ b/roamio-mobile/firebase.js
@@ -1,0 +1,46 @@
+// Firebase initialization for React Native
+import { initializeApp } from 'firebase/app';
+import {
+  getAuth,
+  GoogleAuthProvider,
+} from 'firebase/auth';
+import {
+  getFirestore,
+  initializeFirestore,
+  persistentLocalCache,
+  persistentSingleTabManager,
+} from 'firebase/firestore';
+import { collection, addDoc, serverTimestamp } from "firebase/firestore";
+
+// Values are pulled from native config via process.env or expo-config
+const firebaseConfig = {
+  apiKey: process.env.EXPO_PUBLIC_FIREBASE_API_KEY,
+  authDomain: process.env.EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  projectId: process.env.EXPO_PUBLIC_FIREBASE_PROJECT_ID,
+  storageBucket: process.env.EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  messagingSenderId: process.env.EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+  appId: process.env.EXPO_PUBLIC_FIREBASE_APP_ID,
+};
+
+const app = initializeApp(firebaseConfig);
+const db = initializeFirestore(app, {
+  experimentalForceLongPolling: true,
+  localCache: persistentLocalCache({ tabManager: persistentSingleTabManager() }),
+});
+const auth = getAuth(app);
+const provider = new GoogleAuthProvider();
+
+export { app, db, auth, provider };
+
+export async function submitCustomQuest(data) {
+  const user = auth.currentUser;
+  if (!user) throw new Error('Not authenticated');
+  const payload = {
+    ...data,
+    creatorId: user.uid,
+    createdAt: serverTimestamp(),
+    isPublic: false,
+  };
+  const ref = await addDoc(collection(db, 'custom_quests'), payload);
+  return ref.id;
+}

--- a/roamio-mobile/lib/notifications.js
+++ b/roamio-mobile/lib/notifications.js
@@ -1,0 +1,31 @@
+import * as Notifications from 'expo-notifications';
+import * as Device from 'expo-device';
+import { doc, setDoc } from 'firebase/firestore';
+import { auth, db } from '../firebase';
+import { toast } from './toast';
+
+export async function registerForPushNotifications() {
+  try {
+    let { status } = await Notifications.getPermissionsAsync();
+    if (status !== 'granted') {
+      const res = await Notifications.requestPermissionsAsync();
+      status = res.status;
+    }
+    if (status !== 'granted') {
+      toast('Notification permission denied');
+      return null;
+    }
+    if (!Device.isDevice) {
+      return null;
+    }
+    const token = (await Notifications.getExpoPushTokenAsync()).data;
+    const user = auth.currentUser;
+    if (user) {
+      await setDoc(doc(db, 'users', user.uid), { expoPushToken: token }, { merge: true });
+    }
+    return token;
+  } catch (err) {
+    console.log('Push registration error', err);
+    return null;
+  }
+}

--- a/roamio-mobile/lib/progress.js
+++ b/roamio-mobile/lib/progress.js
@@ -1,0 +1,45 @@
+import { doc, setDoc } from 'firebase/firestore';
+import { auth, db } from '../firebase';
+import Constants from 'expo-constants';
+
+const BASE_URL = Constants.expoConfig.extra.backendUrl || 'http://localhost:8080';
+
+export async function saveQuestProgress(questId, visitedIndices) {
+  const user = auth.currentUser;
+  if (!user || !questId) return;
+  try {
+    await setDoc(
+      doc(db, 'user_quests', user.uid, 'quests', questId),
+      { visitedIndices },
+      { merge: true }
+    );
+  } catch (err) {
+    console.log('Progress save error', err);
+  }
+}
+
+export async function completeQuest(quest) {
+  const user = auth.currentUser;
+  if (!user || !quest?.id) return;
+  const payload = {
+    userId: user.uid,
+    questId: quest.id,
+    title: quest.title,
+    city: quest.city,
+    mood: quest.mood,
+    questText: quest.questText,
+    locationList: quest.places,
+    imageUrl: quest.imageUrl,
+    imagePrompt: quest.imagePrompt,
+    visitedIndices: quest.visitedIndices || [],
+  };
+  try {
+    await fetch(`${BASE_URL}/quest-complete`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  } catch (err) {
+    console.log('Complete quest error', err);
+  }
+}

--- a/roamio-mobile/lib/questApi.js
+++ b/roamio-mobile/lib/questApi.js
@@ -1,0 +1,31 @@
+import Constants from "expo-constants";
+import { auth } from '../firebase';
+import { getIdToken } from 'firebase/auth';
+
+const BASE_URL = Constants.expoConfig.extra.backendUrl || "http://localhost:8080";
+export async function generateQuest({ city, moods, timeLimit, coords }) {
+  const user = auth.currentUser;
+  const token = user ? await getIdToken(user) : null;
+  const payload = {
+    city,
+    moods,
+    time_limit: timeLimit,
+    token,
+    user_id: user?.uid,
+    lat: coords?.lat,
+    lng: coords?.lng,
+  };
+
+  const res = await fetch(`${BASE_URL}/generate-quest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(text);
+  }
+
+  return res.json();
+}

--- a/roamio-mobile/lib/toast.js
+++ b/roamio-mobile/lib/toast.js
@@ -1,0 +1,9 @@
+import { Platform, ToastAndroid, Alert } from 'react-native';
+
+export function toast(message) {
+  if (Platform.OS === 'android') {
+    ToastAndroid.show(message, ToastAndroid.SHORT);
+  } else {
+    Alert.alert('', message);
+  }
+}

--- a/roamio-mobile/navigation/MainNavigator.js
+++ b/roamio-mobile/navigation/MainNavigator.js
@@ -1,0 +1,30 @@
+import React, { useContext } from 'react';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import LoginScreen from '../screens/LoginScreen';
+import HomeScreen from '../screens/HomeScreen';
+import QuestLiveScreen from '../screens/QuestLiveScreen';
+import ProfileScreen from '../screens/ProfileScreen';
+import SettingsScreen from '../screens/SettingsScreen';
+import CustomQuestScreen from '../screens/CustomQuestScreen';
+import { AppContext } from '../context/AppContext';
+
+const Stack = createNativeStackNavigator();
+
+export default function MainNavigator() {
+  const { user } = useContext(AppContext);
+  return (
+    <Stack.Navigator>
+      {user ? (
+        <>
+          <Stack.Screen name="Home" component={HomeScreen} options={{ headerShown: false }} />
+          <Stack.Screen name="QuestLive" component={QuestLiveScreen} options={{ title: 'Quest' }} />
+          <Stack.Screen name="CustomQuest" component={CustomQuestScreen} options={{ title: 'Custom Quest' }} />
+          <Stack.Screen name="Profile" component={ProfileScreen} />
+          <Stack.Screen name="Settings" component={SettingsScreen} />
+        </>
+      ) : (
+        <Stack.Screen name="Login" component={LoginScreen} options={{ headerShown: false }} />
+      )}
+    </Stack.Navigator>
+  );
+}

--- a/roamio-mobile/package.json
+++ b/roamio-mobile/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "roamio-mobile",
+  "version": "0.1.0",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^49.0.0",
+    "expo-auth-session": "~4.0.3",
+    "expo-location": "~15.1.1",
+    "@react-native-community/slider": "^5.0.0",
+    "firebase": "^10.7.0",
+    "nativewind": "^2.0.11",
+    "react": "18.2.0",
+    "react-native": "0.72.4",
+    "react-native-gesture-handler": "~2.12.0",
+    "react-native-maps": "1.8.1",
+    "react-native-reanimated": "~3.3.0",
+    "react-native-safe-area-context": "4.7.1",
+    "react-native-screens": "^3.20.0",
+    "@react-navigation/native": "^6.1.6",
+    "@react-navigation/native-stack": "^6.9.12",
+    "expo-notifications": "~0.20.1",
+    "expo-device": "~5.4.0",
+    "@react-native-async-storage/async-storage": "^1.18.2"
+  }
+}

--- a/roamio-mobile/screens/CustomQuestScreen.jsx
+++ b/roamio-mobile/screens/CustomQuestScreen.jsx
@@ -1,0 +1,134 @@
+import React, { useState, useContext } from 'react';
+import { View, Text, TextInput, Button, ScrollView } from 'react-native';
+import Slider from '@react-native-community/slider';
+import SharedHeader from '../components/SharedHeader';
+import { AppContext } from '../context/AppContext';
+import { submitCustomQuest } from '../firebase';
+import { toast } from '../lib/toast';
+
+export default function CustomQuestScreen({ navigation }) {
+  const { isPremium } = useContext(AppContext);
+  const [title, setTitle] = useState('');
+  const [mood, setMood] = useState('');
+  const [timeLimit, setTimeLimit] = useState(90);
+  const [stops, setStops] = useState([
+    { name: '', type: '', lat: '', lng: '' },
+  ]);
+
+  const addStop = () => {
+    setStops([...stops, { name: '', type: '', lat: '', lng: '' }]);
+  };
+
+  const removeStop = (idx) => {
+    setStops(stops.filter((_, i) => i !== idx));
+  };
+
+  const updateStop = (idx, field, value) => {
+    const arr = [...stops];
+    arr[idx][field] = value;
+    setStops(arr);
+  };
+
+  const handleSubmit = async () => {
+    if (!title.trim()) {
+      toast('Title required');
+      return;
+    }
+    for (const s of stops) {
+      if (!s.name || !s.type || !s.lat || !s.lng) {
+        toast('Fill all stop fields');
+        return;
+      }
+    }
+    try {
+      const locationList = stops.map((s) => ({
+        name: s.name,
+        type: s.type,
+        lat: parseFloat(s.lat),
+        lng: parseFloat(s.lng),
+      }));
+      await submitCustomQuest({ title, mood, timeLimit, locationList });
+      toast('Custom quest saved');
+      navigation.goBack();
+    } catch (err) {
+      console.log('Custom quest save error', err);
+      toast('Failed to save');
+    }
+  };
+
+  if (!isPremium) {
+    return (
+      <View className="flex-1 p-4 items-center">
+        <SharedHeader title="Custom Quest" />
+        <Text className="mt-4 text-center">
+          Custom quests are a Roamio+ feature. Upgrade to plan your own adventures.
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <ScrollView className="flex-1 p-4">
+      <SharedHeader title="Custom Quest" />
+      <TextInput
+        className="border p-2 mb-2"
+        placeholder="Title"
+        value={title}
+        onChangeText={setTitle}
+      />
+      <TextInput
+        className="border p-2 mb-2"
+        placeholder="Mood"
+        value={mood}
+        onChangeText={setMood}
+      />
+      <View className="mb-4">
+        <Text>Time Limit: {timeLimit} minutes</Text>
+        <Slider
+          minimumValue={30}
+          maximumValue={180}
+          step={15}
+          value={timeLimit}
+          onValueChange={setTimeLimit}
+        />
+      </View>
+      {stops.map((stop, idx) => (
+        <View key={idx} className="mb-4 border p-2">
+          <Text className="font-bold">Stop {idx + 1}</Text>
+          <TextInput
+            className="border p-2 mb-1"
+            placeholder="Name"
+            value={stop.name}
+            onChangeText={(t) => updateStop(idx, 'name', t)}
+          />
+          <TextInput
+            className="border p-2 mb-1"
+            placeholder="Type"
+            value={stop.type}
+            onChangeText={(t) => updateStop(idx, 'type', t)}
+          />
+          <TextInput
+            className="border p-2 mb-1"
+            placeholder="Latitude"
+            keyboardType="numeric"
+            value={stop.lat}
+            onChangeText={(t) => updateStop(idx, 'lat', t)}
+          />
+          <TextInput
+            className="border p-2 mb-1"
+            placeholder="Longitude"
+            keyboardType="numeric"
+            value={stop.lng}
+            onChangeText={(t) => updateStop(idx, 'lng', t)}
+          />
+          <Button title="Remove" onPress={() => removeStop(idx)} />
+        </View>
+      ))}
+      <Button title="Add Stop" onPress={addStop} />
+      <View className="mt-4">
+        <Button title="Submit Quest" onPress={handleSubmit} />
+        <Button title="Cancel" onPress={() => navigation.goBack()} className="mt-2" />
+      </View>
+    </ScrollView>
+  );
+}

--- a/roamio-mobile/screens/HomeScreen.jsx
+++ b/roamio-mobile/screens/HomeScreen.jsx
@@ -1,0 +1,88 @@
+import React, { useState, useContext } from 'react';
+import { View, Text, Button, TextInput } from "react-native";
+import Slider from "@react-native-community/slider";
+import * as Location from 'expo-location';
+import { toast } from '../lib/toast';
+import SharedHeader from '../components/SharedHeader';
+import { generateQuest } from '../lib/questApi';
+import { AppContext } from '../context/AppContext';
+
+export default function HomeScreen({ navigation }) {
+  const [location, setLocation] = useState(null);
+  const [city, setCity] = useState('');
+  const [mood, setMood] = useState('');
+  const [timeLimit, setTimeLimit] = useState(60);
+  const [statusMsg, setStatusMsg] = useState('');
+  const { setQuest, isPremium } = useContext(AppContext);
+
+  const openCustomQuest = () => {
+    if (!isPremium) {
+      toast('Custom quests are a Roamio+ feature. Upgrade to plan your own adventures.');
+      return;
+    }
+    navigation.navigate('CustomQuest');
+  };
+
+  const requestLocation = async () => {
+    const { status } = await Location.requestForegroundPermissionsAsync();
+    if (status !== 'granted') {
+      setStatusMsg('Permission denied');
+      toast('Location not shared — routing may be less accurate');
+      return;
+    }
+    const loc = await Location.getCurrentPositionAsync({});
+    setLocation(loc.coords);
+    setStatusMsg('');
+  };
+
+  const handleGenerate = async () => {
+    try {
+      const questData = await generateQuest({
+        city,
+        moods: mood.split(',').map((m) => m.trim()).filter(Boolean),
+        timeLimit,
+        coords: location ? { lat: location.latitude, lng: location.longitude } : undefined,
+      });
+      setQuest({ ...questData.quest, id: questData.hash, visitedIndices: [] });
+      navigation.navigate('QuestLive');
+      if (questData.fallbackCity) {
+        toast(`Showing results near ${questData.fallbackCity}`);
+      }
+    } catch (err) {
+      console.log('Quest error', err);
+      toast('Failed to generate quest');
+    }
+  };
+
+  return (
+    <View className="flex-1 items-center p-4">
+      <SharedHeader title="Home" />
+      <TextInput
+        className="border w-full p-2 mb-2"
+        placeholder="City"
+        value={city}
+        onChangeText={setCity}
+      />
+      <TextInput
+        className="border w-full p-2 mb-2"
+        placeholder="Mood (comma separated)"
+        value={mood}
+        onChangeText={setMood}
+      />
+      <View className="w-full mb-2">
+        <Text>Time Limit: {timeLimit} minutes</Text>
+        <Slider
+          minimumValue={30}
+          maximumValue={180}
+          step={15}
+          value={timeLimit}
+          onValueChange={setTimeLimit}
+        />
+      </View>
+      <Button title="Use GPS" onPress={requestLocation} />
+      {statusMsg ? <Text>{statusMsg}</Text> : null}
+      <Button title="Generate Quest" onPress={handleGenerate} className="mt-4" />
+      <Button title="Custom Quest (Quest+)" onPress={openCustomQuest} className="mt-2" />
+    </View>
+  );
+}

--- a/roamio-mobile/screens/LoginScreen.jsx
+++ b/roamio-mobile/screens/LoginScreen.jsx
@@ -1,0 +1,38 @@
+import React, { useEffect } from 'react';
+import { View, Text, Button } from 'react-native';
+import * as WebBrowser from 'expo-web-browser';
+import * as Google from 'expo-auth-session/providers/google';
+import { makeRedirectUri } from 'expo-auth-session';
+import { signInWithCredential, GoogleAuthProvider } from 'firebase/auth';
+import { auth } from '../firebase';
+
+WebBrowser.maybeCompleteAuthSession();
+
+export default function LoginScreen({ navigation }) {
+  const [request, response, promptAsync] = Google.useAuthRequest({
+    expoClientId: process.env.EXPO_PUBLIC_GOOGLE_EXPO_CLIENT_ID,
+    iosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID,
+    androidClientId: process.env.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID,
+    webClientId: process.env.EXPO_PUBLIC_GOOGLE_WEB_CLIENT_ID,
+    redirectUri: makeRedirectUri({ useProxy: true }),
+  });
+
+  useEffect(() => {
+    if (response?.type === 'success') {
+      const { id_token, access_token } = response.params;
+      const credential = GoogleAuthProvider.credential(id_token, access_token);
+      signInWithCredential(auth, credential).catch((err) => console.error(err));
+    }
+  }, [response]);
+
+  return (
+    <View className="flex-1 items-center justify-center bg-white">
+      <Text className="text-2xl mb-4">Roamio</Text>
+      <Button
+        title="Sign in with Google"
+        disabled={!request}
+        onPress={() => promptAsync({ useProxy: true })}
+      />
+    </View>
+  );
+}

--- a/roamio-mobile/screens/ProfileScreen.jsx
+++ b/roamio-mobile/screens/ProfileScreen.jsx
@@ -1,0 +1,47 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { View, Text, Image, FlatList } from 'react-native';
+import SharedHeader from '../components/SharedHeader';
+import { AppContext } from '../context/AppContext';
+import { collection, getDocs } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export default function ProfileScreen() {
+  const { user } = useContext(AppContext);
+  const [postcards, setPostcards] = useState([]);
+
+  useEffect(() => {
+    async function load() {
+      if (!user) return;
+      try {
+        const q = collection(db, 'user_quests', user.uid, 'quests');
+        const snap = await getDocs(q);
+        const arr = [];
+        snap.forEach((doc) => {
+          const data = doc.data();
+          if (data.imageUrl) arr.push({ id: doc.id, url: data.imageUrl });
+        });
+        setPostcards(arr);
+      } catch (err) {
+        console.log('Postcard fetch error', err);
+      }
+    }
+    load();
+  }, [user]);
+
+  return (
+    <View className="flex-1 p-4 items-center">
+      <SharedHeader title="Profile" />
+      <FlatList
+        data={postcards}
+        numColumns={3}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <Image source={{ uri: item.url }} className="w-24 h-24 m-1" />
+        )}
+        ListEmptyComponent={
+          <Text>You haven\u2019t completed any quests yet!</Text>
+        }
+      />
+    </View>
+  );
+}

--- a/roamio-mobile/screens/QuestLiveScreen.jsx
+++ b/roamio-mobile/screens/QuestLiveScreen.jsx
@@ -1,0 +1,111 @@
+import React, { useContext, useState, useEffect, useRef } from 'react';
+import { View, Text, Button, FlatList } from 'react-native';
+import MapView, { Marker, Polyline } from 'react-native-maps';
+import SharedHeader from '../components/SharedHeader';
+import { AppContext } from '../context/AppContext';
+import { saveQuestProgress, completeQuest } from '../lib/progress';
+import * as Notifications from 'expo-notifications';
+
+export default function QuestLiveScreen({ navigation }) {
+  const { quest, setQuest } = useContext(AppContext);
+  const [step, setStep] = useState(quest?.visitedIndices?.length || 0);
+  const mapRef = useRef(null);
+
+  useEffect(() => {
+    if (step === 1) {
+      const t = setTimeout(() => {
+        Notifications.scheduleNotificationAsync({
+          content: {
+            title: 'Next Stop Ahead!',
+            body: 'Your next destination is just a few minutes away.',
+          },
+          trigger: null,
+        });
+      }, 15000);
+      return () => clearTimeout(t);
+    }
+  }, [step]);
+
+  useEffect(() => {
+    if (!quest || !mapRef.current) return;
+    const place = quest.places[step] || quest.places[quest.places.length - 1];
+    mapRef.current.animateToRegion(
+      {
+        latitude: place.lat,
+        longitude: place.lng,
+        latitudeDelta: 0.05,
+        longitudeDelta: 0.05,
+      },
+      500
+    );
+  }, [step, quest]);
+
+  if (!quest) {
+    return (
+      <View className="flex-1 items-center justify-center">
+        <Text>No active quest</Text>
+      </View>
+    );
+  }
+
+  const region = {
+    latitude: quest.places[0].lat,
+    longitude: quest.places[0].lng,
+    latitudeDelta: 0.05,
+    longitudeDelta: 0.05,
+  };
+
+  const handleVisit = async () => {
+    const visited = [...(quest.visitedIndices || []), step];
+    const updated = { ...quest, visitedIndices: visited };
+    setQuest(updated);
+    await saveQuestProgress(quest.id, visited);
+    setStep(step + 1);
+  };
+
+  const handleComplete = async () => {
+    await completeQuest({ ...quest, visitedIndices: quest.visitedIndices || [] });
+    setQuest(null);
+    navigation.navigate('Profile');
+  };
+
+  return (
+    <View className="flex-1">
+      <SharedHeader title="Quest" />
+      <MapView ref={mapRef} style={{ flex: 1 }} initialRegion={region}>
+        {quest.places.map((p, idx) => (
+          <Marker
+            key={idx}
+            coordinate={{ latitude: p.lat, longitude: p.lng }}
+            title={p.name}
+            pinColor={idx === step ? 'blue' : 'gray'}
+          />
+        ))}
+        {step < quest.places.length - 1 && (
+          <Polyline
+            coordinates={[
+              { latitude: quest.places[step].lat, longitude: quest.places[step].lng },
+              { latitude: quest.places[step + 1].lat, longitude: quest.places[step + 1].lng },
+            ]}
+            strokeColor="blue"
+            strokeWidth={3}
+          />
+        )}
+      </MapView>
+      <View className="p-2">
+        <FlatList
+          data={quest.places}
+          keyExtractor={(item, i) => `${item.name}-${i}`}
+          renderItem={({ item, index }) => (
+            <Text className={index === step ? 'font-bold' : ''}>{item.name}</Text>
+          )}
+        />
+        {step < quest.places.length - 1 ? (
+          <Button title="Mark as Visited" onPress={handleVisit} />
+        ) : (
+          <Button title="Complete Quest" onPress={handleComplete} />
+        )}
+      </View>
+    </View>
+  );
+}

--- a/roamio-mobile/screens/SettingsScreen.jsx
+++ b/roamio-mobile/screens/SettingsScreen.jsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { View, Text, Button } from 'react-native';
+import { signOut } from 'firebase/auth';
+import { auth } from '../firebase';
+import SharedHeader from '../components/SharedHeader';
+
+export default function SettingsScreen() {
+  return (
+    <View className="flex-1 items-center justify-center">
+      <SharedHeader title="Settings" />
+      <Button title="Logout" onPress={() => signOut(auth)} />
+      <Text className="mt-4">Notifications (coming soon)</Text>
+    </View>
+  );
+}

--- a/roamio-mobile/tailwind.config.js
+++ b/roamio-mobile/tailwind.config.js
@@ -1,0 +1,15 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './App.js',
+    './context/**/*.{js,jsx,ts,tsx}',
+    './lib/**/*.{js,jsx,ts,tsx}',
+    './screens/**/*.{js,jsx,ts,tsx}',
+    './components/**/*.{js,jsx,ts,tsx}',
+    './navigation/**/*.{js,jsx,ts,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- create `CustomQuestScreen` for premium users to build quests
- gate access via `isPremium` with upgrade prompt
- expose `submitCustomQuest` helper in Firebase setup
- add navigation route and entry button from home screen
- integrate Stripe webhook and premium validation endpoint
- add Pricing page and PremiumGuard component for gating

## Testing
- `python -m py_compile backend/main.py`
- `node tests/firestoreRules.test.js` *(fails: module '@firebase/rules-unit-testing' not found)*

------
https://chatgpt.com/codex/tasks/task_e_6881a15ed3b0832188b419ec204752de