### PR TITLE
Add welcome page and login modal

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -6,6 +6,7 @@ import { doc, getDoc } from "firebase/firestore";
 import { db } from "./firebase";
 import { getActiveQuest, getQuest, leaveGroup } from "./lib/api";
 import LandingPage from "./components/LandingPage";
+import WelcomePage from "./pages/WelcomePage";
 import QuestHome from "./components/QuestHome";
 import QuestDetails from "./components/QuestDetails";
 import QuestHistory from "./components/QuestHistory";
@@ -62,9 +63,10 @@ function App() {
 
   return (
     <>
-      <Header />
+      {location.pathname !== '/' && <Header />}
       <Routes>
-        <Route path="/" element={<LandingPage />} />
+        <Route path="/" element={<WelcomePage />} />
+        <Route path="/landing" element={<LandingPage />} />
         <Route path="/home" element={<QuestHome />} />
         <Route path="/details" element={<QuestDetails />} />
         <Route path="/quest/:city/:mood/route" element={<QuestRoute />} />
@@ -88,7 +90,7 @@ function App() {
         <Route path="/payment-success" element={<PaymentSuccess />} />
         <Route path="/payment-failed" element={<PaymentFailed />} />
       </Routes>
-      <Footer />
+      {location.pathname !== '/' && <Footer />}
       <CookieConsent
         location="bottom"
         buttonText="I Agree"

--- a/frontend/src/components/GroupQuestView.jsx
+++ b/frontend/src/components/GroupQuestView.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import LiveQuestMap from './LiveQuestMap';
 import GroupMemberList from './GroupMemberList';
-import { getGroupQuest, getQuest, trackStopVisit } from '../lib/api';
+import { getQuest, trackStopVisit } from '../lib/api';
 import { decode } from '@googlemaps/polyline-codec';
 import { doc, onSnapshot, getDoc } from 'firebase/firestore';
 import { db } from '../firebase';

--- a/frontend/src/components/LoginModal.jsx
+++ b/frontend/src/components/LoginModal.jsx
@@ -1,0 +1,118 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  signInWithPopup,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signInAnonymously,
+  getAuth,
+} from 'firebase/auth';
+import { auth, provider } from '../firebase';
+
+export default function LoginModal() {
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPass, setShowPass] = useState(false);
+  const [error, setError] = useState('');
+
+  const handleGoogle = async () => {
+    try {
+      await signInWithPopup(auth, provider);
+      navigate('/home');
+    } catch (err) {
+      console.error('Google login failed', err);
+      setError('Login failed');
+    }
+  };
+
+  const handleEmail = async (e) => {
+    e.preventDefault();
+    setError('');
+    try {
+      await signInWithEmailAndPassword(auth, email, password);
+      navigate('/home');
+    } catch (err) {
+      if (err.code === 'auth/user-not-found') {
+        try {
+          await createUserWithEmailAndPassword(auth, email, password);
+          navigate('/home');
+          return;
+        } catch (err2) {
+          console.error('signup failed', err2);
+          setError('Invalid email or password');
+        }
+      } else {
+        console.error('email login failed', err);
+        setError('Invalid email or password');
+      }
+    }
+  };
+
+  const handleGuest = async () => {
+    try {
+      await signInAnonymously(getAuth());
+      navigate('/home');
+    } catch (err) {
+      console.error('guest login failed', err);
+      setError('Could not start guest session');
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/60 flex items-center justify-center">
+      <div className="bg-white p-6 rounded-lg w-80 space-y-4 text-center">
+        <h2 className="text-xl font-bold">Welcome to Roamio</h2>
+        <div className="space-y-3">
+          <button
+            onClick={handleGoogle}
+            className="w-full bg-red-500 text-white py-2 rounded-full"
+          >
+            Sign in with Google
+          </button>
+          <div className="text-xs text-gray-500">Fast &amp; secure</div>
+          <form onSubmit={handleEmail} className="space-y-2">
+            <input
+              type="email"
+              required
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="Email"
+              className="w-full border rounded px-3 py-2"
+            />
+            <div className="relative">
+              <input
+                type={showPass ? 'text' : 'password'}
+                required
+                minLength={6}
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                placeholder="Password"
+                className="w-full border rounded px-3 py-2 pr-10"
+              />
+              <button
+                type="button"
+                onClick={() => setShowPass(!showPass)}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-sm text-gray-600"
+              >
+                {showPass ? 'Hide' : 'Show'}
+              </button>
+            </div>
+            <button className="w-full bg-[#019863] text-white py-2 rounded-full">
+              Continue with Email
+            </button>
+          </form>
+          <div className="text-xs text-gray-500">Use any email</div>
+          <button
+            onClick={handleGuest}
+            className="w-full bg-gray-200 text-gray-800 py-2 rounded-full"
+          >
+            Continue as Guest
+          </button>
+          <div className="text-xs text-gray-500">Try Roamio before committing</div>
+          {error && <div className="text-red-600 text-sm">{error}</div>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/lib/firebase.js
+++ b/frontend/src/lib/firebase.js
@@ -1,0 +1,30 @@
+import {
+  signInWithPopup,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signInAnonymously,
+} from 'firebase/auth';
+import { auth, provider } from '../firebase';
+
+export async function googleLogin() {
+  const result = await signInWithPopup(auth, provider);
+  return result.user;
+}
+
+export async function emailLogin(email, password) {
+  try {
+    const res = await signInWithEmailAndPassword(auth, email, password);
+    return res.user;
+  } catch (err) {
+    if (err.code === 'auth/user-not-found') {
+      const res = await createUserWithEmailAndPassword(auth, email, password);
+      return res.user;
+    }
+    throw err;
+  }
+}
+
+export async function guestLogin() {
+  const res = await signInAnonymously(auth);
+  return res.user;
+}

--- a/frontend/src/pages/WelcomePage.jsx
+++ b/frontend/src/pages/WelcomePage.jsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+import GoogleMapReact from 'google-map-react';
+import LoginModal from '../components/LoginModal';
+
+const demoQuests = [
+  { title: "\uD83C\uDF55 Pizza Crawl", lat: 40.7201, lng: -73.9993 },
+  { title: "\uD83D\uDDBC\uFE0F Hidden Art Hunt", lat: 40.7153, lng: -74.0031 },
+  { title: "\uD83C\uDF3F Park Explorer", lat: 40.7128, lng: -74.006 },
+];
+
+const moods = ['Adventure', 'Romantic', 'Weird'];
+
+export default function WelcomePage() {
+  const [showModal, setShowModal] = useState(false);
+  const [active, setActive] = useState([]);
+
+  const handleInteract = () => setShowModal(true);
+
+  const toggleMood = (m) => {
+    handleInteract();
+    setActive((prev) =>
+      prev.includes(m) ? prev.filter((x) => x !== m) : [...prev, m]
+    );
+  };
+
+  return (
+    <div className="relative w-screen h-screen">
+      {showModal && <LoginModal />}
+      <div className="absolute inset-0">
+        <GoogleMapReact
+          bootstrapURLKeys={{ key: import.meta.env.VITE_GOOGLE_MAPS_API_KEY }}
+          defaultCenter={{ lat: 40.7153, lng: -74.0031 }}
+          defaultZoom={13}
+          yesIWantToUseGoogleMapApiInternals
+        >
+          {demoQuests.map((q, i) => (
+            <div
+              key={i}
+              lat={q.lat}
+              lng={q.lng}
+              title={q.title}
+              className="text-2xl cursor-pointer"
+              onClick={handleInteract}
+            >
+              📍
+            </div>
+          ))}
+        </GoogleMapReact>
+      </div>
+      <div className="absolute top-4 left-4 bg-white bg-opacity-70 rounded-full px-3 py-1 text-sm shadow">
+        <span className="opacity-50">Streak: 0 days 🔒</span>
+      </div>
+      <div className="absolute bottom-24 left-1/2 -translate-x-1/2 flex gap-2">
+        {moods.map((m) => (
+          <button
+            key={m}
+            onClick={() => toggleMood(m)}
+            className={`text-sm px-3 py-1 rounded-full backdrop-blur bg-white bg-opacity-70 ${active.includes(m) ? 'bg-[#019863] text-white' : ''}`}
+          >
+            {m}
+          </button>
+        ))}
+      </div>
+      <div className="absolute bottom-8 left-1/2 -translate-x-1/2">
+        <button
+          onClick={handleInteract}
+          className="bg-[#019863] text-white px-6 py-3 rounded-full shadow-lg"
+        >
+          Feeling Lucky?
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create `WelcomePage` with demo quests and mood filters
- add `LoginModal` with Google/email/guest auth
- expose helper auth functions in `src/lib/firebase.js`
- hide header/footer on the welcome route
- clean up unused variable in `GroupQuestView`

## Testing
- `npm run lint`
- `npm run build` *(fails: Could not resolve '../lib/toast' in CustomQuestBuilder.jsx)*
- `node tests/firestoreRules.test.js` *(fails: Firestore emulator not specified)*

------
https://chatgpt.com/codex/tasks/task_e_688255d0d2fc8321ad713e2c316bc515