### PR TITLE
Implement UGC weekly tag submission system

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -870,7 +870,18 @@ async def complete_quest(payload: dict = Body(...)):
         user_data = _decode_document(resp.json())
 
     difficulty = (payload.get("difficulty") or "Easy").title()
-    xp_earned = 25 if difficulty == "Easy" else 50 if difficulty == "Medium" else 75
+    base_xp = 25 if difficulty == "Easy" else 50 if difficulty == "Medium" else 75
+    xp_earned = base_xp
+    bonus_xp = 0
+    if user_data.get("ugcBoostActive"):
+        cfg_url = (
+            f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/config/ugcWeeklyTag"
+        )
+        cfg_resp = await asyncio.to_thread(rest_session.get, cfg_url)
+        cfg = _decode_document(cfg_resp.json()) if cfg_resp.status_code == 200 else {}
+        mult = float(cfg.get("xpMultiplier", 1.2))
+        xp_earned = int(base_xp * mult)
+        bonus_xp = xp_earned - base_xp
     level_before = user_data.get("level", 1)
     total_xp = user_data.get("totalXP", 0) + xp_earned
     level = get_level_from_xp(total_xp)
@@ -894,6 +905,7 @@ async def complete_quest(payload: dict = Body(...)):
         "levelBefore": level_before,
         "levelAfter": level,
         "badgesUnlocked": new_badges,
+        "bonusXP": bonus_xp,
     })
     # Update quest document with summary details
     summary_body = {"fields": _encode_fields({
@@ -901,21 +913,21 @@ async def complete_quest(payload: dict = Body(...)):
         "levelBefore": level_before,
         "levelAfter": level,
         "badgesUnlocked": new_badges,
+        "bonusXP": bonus_xp,
     })}
     await asyncio.to_thread(rest_session.patch, quest_url, json=summary_body)
 
-    user_body = {
-        "fields": _encode_fields(
-            {
-                "totalXP": total_xp,
-                "level": level,
-                "stats": stats,
-                "badges": badges,
-                "badgesUnlocked": badge_list,
-                "lastActive": timestamp,
-            }
-        )
+    user_update = {
+        "totalXP": total_xp,
+        "level": level,
+        "stats": stats,
+        "badges": badges,
+        "badgesUnlocked": badge_list,
+        "lastActive": timestamp,
     }
+    if user_data.get("ugcBoostActive"):
+        user_update["ugcBoostActive"] = False
+    user_body = {"fields": _encode_fields(user_update)}
     resp = await asyncio.to_thread(rest_session.patch, user_url, json=user_body)
     if resp.status_code != 200:
         print("Firestore REST error", resp.text)
@@ -968,6 +980,7 @@ async def complete_quest(payload: dict = Body(...)):
     return {
         "status": "completed",
         "xpEarned": xp_earned,
+        "bonusXP": bonus_xp,
         "newTotal": total_xp,
         "level": level,
         "badgesUnlocked": new_badges,
@@ -1624,6 +1637,62 @@ async def toggle_quest_visibility(payload: dict = Body(...)):
         print("Firestore REST error", resp.text)
         resp.raise_for_status()
     return {"status": "updated"}
+
+
+@app.post("/ugc-submit")
+async def ugc_submit(request: Request, payload: dict = Body(...)):
+    """Record a user's social media submission for the weekly tag."""
+    uid = await _verify_token(request.headers.get("Authorization"))
+    if not uid or uid != payload.get("uid"):
+        return JSONResponse(status_code=401, content={"error": "unauthorized"})
+    tag = payload.get("tag")
+    platform = payload.get("platform")
+    image_url = payload.get("imageUrl")
+    if not tag or not platform:
+        return {"error": "tag and platform required"}
+    project_id = creds.project_id
+    cfg_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/config/ugcWeeklyTag"
+    cfg_resp = await asyncio.to_thread(rest_session.get, cfg_url)
+    cfg = _decode_document(cfg_resp.json()) if cfg_resp.status_code == 200 else {}
+    active_tag = cfg.get("activeTag")
+    if tag != active_tag:
+        return {"error": "invalidTag"}
+    user_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/users/{uid}"
+    uresp = await asyncio.to_thread(rest_session.get, user_url)
+    ufields = _decode_document(uresp.json()) if uresp.status_code == 200 else {}
+    used = ufields.get("ugcTagsUsed", [])
+    if active_tag in used:
+        return {"error": "duplicate"}
+    doc_id = hashlib.sha1(f"{uid}-{tag}".encode()).hexdigest()[:16]
+    sub_doc = {
+        "uid": uid,
+        "tag": tag,
+        "platform": platform,
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+    if image_url:
+        sub_doc["imageUrl"] = image_url
+    sub_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/ugc_submissions/{doc_id}"
+    await asyncio.to_thread(rest_session.patch, sub_url, json={"fields": _encode_fields(sub_doc)})
+    used.append(active_tag)
+    ufields.update({
+        "lastUGCSubmission": datetime.utcnow().isoformat(),
+        "ugcBoostActive": True,
+        "ugcTagsUsed": used,
+    })
+    await asyncio.to_thread(rest_session.patch, user_url, json={"fields": _encode_fields(ufields)})
+    return {"status": "ok", "xpMultiplier": cfg.get("xpMultiplier", 1.0)}
+
+
+@app.get("/config/ugcWeeklyTag")
+async def get_weekly_tag():
+    """Return current UGC weekly tag configuration."""
+    project_id = creds.project_id
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/config/ugcWeeklyTag"
+    resp = await asyncio.to_thread(rest_session.get, url)
+    if resp.status_code != 200:
+        return {}
+    return _decode_document(resp.json())
 
 
 @app.get("/get-community-quests")

--- a/firestore.rules
+++ b/firestore.rules
@@ -71,6 +71,17 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId && !isBanned();
     }
 
+    // ===== UGC Submissions =====
+    match /ugc_submissions/{id} {
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.uid && !isBanned();
+      allow read, delete: if isAdmin();
+    }
+
+    match /config/ugcWeeklyTag {
+      allow read: if true;
+      allow write: if isAdmin();
+    }
+
     // ===== Admin Config =====
     match /config/admins {
       allow read, write: if isAdmin();

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -31,6 +31,7 @@ import Explore from "./components/Explore";
 import GroupQuestView from "./components/GroupQuestView";
 import Terms from "./pages/Terms";
 import Privacy from "./pages/Privacy";
+import UGCSubmitForm from "./components/UGCSubmitForm";
 import CookieConsent from "react-cookie-consent";
 
 
@@ -97,6 +98,7 @@ function App() {
         <Route path="/tag-editor/:questId" element={<TagEditor />} />
         <Route path="/terms" element={<Terms />} />
         <Route path="/privacy" element={<Privacy />} />
+        <Route path="/ugc-submit" element={<UGCSubmitForm />} />
         <Route path="/payment-success" element={<PaymentSuccess />} />
         <Route path="/payment-failed" element={<PaymentFailed />} />
       </Routes>

--- a/frontend/src/components/UGCSubmitForm.jsx
+++ b/frontend/src/components/UGCSubmitForm.jsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import { getAuth } from 'firebase/auth';
+import { fetchWeeklyTagConfig } from '../lib/xpBoostHelpers';
+import { submitUGC } from '../lib/api';
+import { toast } from '../lib/toast';
+
+export default function UGCSubmitForm() {
+  const [tag, setTag] = useState('');
+  const [platform, setPlatform] = useState('Instagram');
+  const [multiplier, setMultiplier] = useState(1);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const cfg = await fetchWeeklyTagConfig();
+      if (cfg.activeTag) setTag(cfg.activeTag);
+      if (cfg.xpMultiplier) setMultiplier(cfg.xpMultiplier);
+    })();
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user) return toast('Login required');
+    setLoading(true);
+    try {
+      await submitUGC({ uid: user.uid, tag, platform });
+      toast(`Great! Your next quest will earn ${multiplier}x XP!`);
+    } catch (err) {
+      console.error('ugc submit failed', err);
+      toast('Submission failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f8fcf8] p-6 text-[#0e1b0e]">
+      <h1 className="text-xl font-bold mb-4">Share Your Quest</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+        <div>
+          <label className="block text-sm mb-1">Platform</label>
+          <select
+            className="border rounded p-2 w-full"
+            value={platform}
+            onChange={(e) => setPlatform(e.target.value)}
+          >
+            <option>Instagram</option>
+            <option>Twitter</option>
+            <option>TikTok</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Tag</label>
+          <input
+            className="border rounded p-2 w-full"
+            value={tag}
+            onChange={(e) => setTag(e.target.value)}
+          />
+        </div>
+        <button
+          className="w-full bg-blue-600 text-white py-2 rounded"
+          disabled={loading}
+        >
+          {loading ? 'Submitting...' : 'Submit'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -553,6 +553,20 @@ export async function banUser(userId, targetId) {
   return resp.json();
 }
 
+export async function submitUGC(payload) {
+  const auth = getAuth();
+  const user = auth.currentUser;
+  if (!user) throw new Error('Auth required');
+  const token = await user.getIdToken();
+  const resp = await fetch(`${BASE_URL}/ugc-submit`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(payload)
+  });
+  if (!resp.ok) throw new Error('Failed to submit');
+  return resp.json();
+}
+
 // ===== Group Chat =====
 
 export async function sendMessage(groupId, senderId, senderName, text) {

--- a/frontend/src/lib/firebase.js
+++ b/frontend/src/lib/firebase.js
@@ -52,3 +52,8 @@ export async function setSkipSharePrompt(userId, value) {
   if (!userId) return;
   await updateDoc(doc(db, 'users', userId), { skipSharePrompt: value });
 }
+
+export async function setUGCBoostActive(userId, value) {
+  if (!userId) return;
+  await updateDoc(doc(db, 'users', userId), { ugcBoostActive: value });
+}

--- a/frontend/src/lib/xpBoostHelpers.js
+++ b/frontend/src/lib/xpBoostHelpers.js
@@ -1,0 +1,11 @@
+export function applyXPBoost(xp, multiplier = 1) {
+  return Math.round(xp * multiplier);
+}
+
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export async function fetchWeeklyTagConfig() {
+  const snap = await getDoc(doc(db, 'config', 'ugcWeeklyTag'));
+  return snap.exists() ? snap.data() : {};
+}


### PR DESCRIPTION
## Summary
- create XP boost helpers and UGC submit form
- allow UGC submission via `/ugc-submit` and return weekly tag config
- apply XP multiplier for UGC boosts when completing quests
- expose weekly tag config via backend
- update Firestore rules for UGC
- wire up frontend routes and API helpers

## Testing
- `node tests/firestoreRules.test.js` *(fails: Firestore emulator host/port not specified)*

------
https://chatgpt.com/codex/tasks/task_e_6882719e98fc8321a80ece73f7af6c88