### PR TITLE
Implement creator dashboard and UGC analytics

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -870,7 +870,18 @@ async def complete_quest(payload: dict = Body(...)):
         user_data = _decode_document(resp.json())
 
     difficulty = (payload.get("difficulty") or "Easy").title()
-    xp_earned = 25 if difficulty == "Easy" else 50 if difficulty == "Medium" else 75
+    base_xp = 25 if difficulty == "Easy" else 50 if difficulty == "Medium" else 75
+    xp_earned = base_xp
+    bonus_xp = 0
+    if user_data.get("ugcBoostActive"):
+        cfg_url = (
+            f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/config/ugcWeeklyTag"
+        )
+        cfg_resp = await asyncio.to_thread(rest_session.get, cfg_url)
+        cfg = _decode_document(cfg_resp.json()) if cfg_resp.status_code == 200 else {}
+        mult = float(cfg.get("xpMultiplier", 1.2))
+        xp_earned = int(base_xp * mult)
+        bonus_xp = xp_earned - base_xp
     level_before = user_data.get("level", 1)
     total_xp = user_data.get("totalXP", 0) + xp_earned
     level = get_level_from_xp(total_xp)
@@ -894,6 +905,7 @@ async def complete_quest(payload: dict = Body(...)):
         "levelBefore": level_before,
         "levelAfter": level,
         "badgesUnlocked": new_badges,
+        "bonusXP": bonus_xp,
     })
     # Update quest document with summary details
     summary_body = {"fields": _encode_fields({
@@ -901,21 +913,21 @@ async def complete_quest(payload: dict = Body(...)):
         "levelBefore": level_before,
         "levelAfter": level,
         "badgesUnlocked": new_badges,
+        "bonusXP": bonus_xp,
     })}
     await asyncio.to_thread(rest_session.patch, quest_url, json=summary_body)
 
-    user_body = {
-        "fields": _encode_fields(
-            {
-                "totalXP": total_xp,
-                "level": level,
-                "stats": stats,
-                "badges": badges,
-                "badgesUnlocked": badge_list,
-                "lastActive": timestamp,
-            }
-        )
+    user_update = {
+        "totalXP": total_xp,
+        "level": level,
+        "stats": stats,
+        "badges": badges,
+        "badgesUnlocked": badge_list,
+        "lastActive": timestamp,
     }
+    if user_data.get("ugcBoostActive"):
+        user_update["ugcBoostActive"] = False
+    user_body = {"fields": _encode_fields(user_update)}
     resp = await asyncio.to_thread(rest_session.patch, user_url, json=user_body)
     if resp.status_code != 200:
         print("Firestore REST error", resp.text)
@@ -946,18 +958,20 @@ async def complete_quest(payload: dict = Body(...)):
     if payload.get("public"):
         feed_id = f"{quest_id}_{user_id}"
         feed_doc = {
+            "uid": user_id,
+            "imageUrl": postcard_url,
             "city": payload.get("city"),
-            "mood": payload.get("mood"),
+            "timestamp": timestamp,
+            "badgesUnlocked": new_badges,
+            "xpEarned": xp_earned,
             "displayName": payload.get("displayName"),
-            "imageUrl": payload.get("imageUrl"),
-            "questText": payload.get("questText"),
-            "completedAt": timestamp,
-            "userId": user_id,
-            "questId": quest_id,
-            "title": payload.get("title"),
+            "mood": payload.get("mood"),
+            "questTitle": payload.get("title"),
+            "sharedFromQuestId": quest_id,
+            "isFlagged": False,
         }
         feed_url = (
-            f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/community_quests/{feed_id}"
+            f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/ugc_feed/{feed_id}"
         )
         feed_body = {"fields": _encode_fields(feed_doc)}
         fr = await asyncio.to_thread(rest_session.patch, feed_url, json=feed_body)
@@ -968,6 +982,7 @@ async def complete_quest(payload: dict = Body(...)):
     return {
         "status": "completed",
         "xpEarned": xp_earned,
+        "bonusXP": bonus_xp,
         "newTotal": total_xp,
         "level": level,
         "badgesUnlocked": new_badges,
@@ -1495,7 +1510,16 @@ async def get_user_xp(user_id: str):
     url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/users/{user_id}"
     resp = await asyncio.to_thread(rest_session.get, url)
     if resp.status_code != 200:
-        return {"totalXP": 0, "level": 1, "badgesUnlocked": [], "showRoamioWatermark": True, "skipSharePrompt": False}
+        return {
+            "totalXP": 0,
+            "level": 1,
+            "badgesUnlocked": [],
+            "showRoamioWatermark": True,
+            "skipSharePrompt": False,
+            "publicSharingOptIn": False,
+            "showUsernameOnShare": True,
+            "showCityOnShare": True,
+        }
     data = _decode_document(resp.json())
     return {
         "totalXP": data.get("totalXP", 0),
@@ -1503,6 +1527,9 @@ async def get_user_xp(user_id: str):
         "badgesUnlocked": data.get("badgesUnlocked", []),
         "showRoamioWatermark": data.get("showRoamioWatermark", True),
         "skipSharePrompt": data.get("skipSharePrompt", False),
+        "publicSharingOptIn": data.get("publicSharingOptIn", False),
+        "showUsernameOnShare": data.get("showUsernameOnShare", True),
+        "showCityOnShare": data.get("showCityOnShare", True),
     }
 
 
@@ -1626,6 +1653,62 @@ async def toggle_quest_visibility(payload: dict = Body(...)):
     return {"status": "updated"}
 
 
+@app.post("/ugc-submit")
+async def ugc_submit(request: Request, payload: dict = Body(...)):
+    """Record a user's social media submission for the weekly tag."""
+    uid = await _verify_token(request.headers.get("Authorization"))
+    if not uid or uid != payload.get("uid"):
+        return JSONResponse(status_code=401, content={"error": "unauthorized"})
+    tag = payload.get("tag")
+    platform = payload.get("platform")
+    image_url = payload.get("imageUrl")
+    if not tag or not platform:
+        return {"error": "tag and platform required"}
+    project_id = creds.project_id
+    cfg_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/config/ugcWeeklyTag"
+    cfg_resp = await asyncio.to_thread(rest_session.get, cfg_url)
+    cfg = _decode_document(cfg_resp.json()) if cfg_resp.status_code == 200 else {}
+    active_tag = cfg.get("activeTag")
+    if tag != active_tag:
+        return {"error": "invalidTag"}
+    user_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/users/{uid}"
+    uresp = await asyncio.to_thread(rest_session.get, user_url)
+    ufields = _decode_document(uresp.json()) if uresp.status_code == 200 else {}
+    used = ufields.get("ugcTagsUsed", [])
+    if active_tag in used:
+        return {"error": "duplicate"}
+    doc_id = hashlib.sha1(f"{uid}-{tag}".encode()).hexdigest()[:16]
+    sub_doc = {
+        "uid": uid,
+        "tag": tag,
+        "platform": platform,
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+    if image_url:
+        sub_doc["imageUrl"] = image_url
+    sub_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/ugc_submissions/{doc_id}"
+    await asyncio.to_thread(rest_session.patch, sub_url, json={"fields": _encode_fields(sub_doc)})
+    used.append(active_tag)
+    ufields.update({
+        "lastUGCSubmission": datetime.utcnow().isoformat(),
+        "ugcBoostActive": True,
+        "ugcTagsUsed": used,
+    })
+    await asyncio.to_thread(rest_session.patch, user_url, json={"fields": _encode_fields(ufields)})
+    return {"status": "ok", "xpMultiplier": cfg.get("xpMultiplier", 1.0)}
+
+
+@app.get("/config/ugcWeeklyTag")
+async def get_weekly_tag():
+    """Return current UGC weekly tag configuration."""
+    project_id = creds.project_id
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/config/ugcWeeklyTag"
+    resp = await asyncio.to_thread(rest_session.get, url)
+    if resp.status_code != 200:
+        return {}
+    return _decode_document(resp.json())
+
+
 @app.get("/get-community-quests")
 async def get_community_quests():
     """Return recently completed public quests."""
@@ -1656,6 +1739,44 @@ async def get_community_quests():
         obj["id"] = doc["name"].split("/")[-1]
         results.append(obj)
     return {"quests": results}
+
+
+@app.get("/ugc-feed")
+async def get_ugc_feed(mood: str | None = Query(None), city: str | None = Query(None)):
+    """Return public UGC feed entries with optional filters."""
+    project_id = creds.project_id
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/ugc_feed:runQuery"
+    filters = []
+    if mood:
+        filters.append({"fieldFilter": {"field": {"fieldPath": "mood"}, "op": "EQUAL", "value": {"stringValue": mood}}})
+    if city:
+        filters.append({"fieldFilter": {"field": {"fieldPath": "city"}, "op": "EQUAL", "value": {"stringValue": city}}})
+    query = {
+        "structuredQuery": {
+            "from": [{"collectionId": "ugc_feed"}],
+            "orderBy": [{"field": {"fieldPath": "timestamp"}, "direction": "DESCENDING"}],
+            "limit": 20,
+        }
+    }
+    if filters:
+        where = filters[0] if len(filters) == 1 else {"compositeFilter": {"op": "AND", "filters": filters}}
+        query["structuredQuery"]["where"] = where
+    resp = await asyncio.to_thread(rest_session.post, url, json=query)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+    raw = resp.json()
+    posts = []
+    for item in raw:
+        doc = item.get("document")
+        if not doc:
+            continue
+        obj = _decode_document(doc)
+        if obj.get("isFlagged"):
+            continue
+        obj["id"] = doc["name"].split("/")[-1]
+        posts.append(obj)
+    return {"posts": posts}
 
 @app.post("/create-checkout-session")
 async def create_checkout_session(payload: dict = Body(...)):
@@ -2553,6 +2674,15 @@ async def _verify_admin(user_id: str) -> bool:
         return data.get("isAdmin") is True
     return False
 
+async def _verify_creator(user_id: str) -> bool:
+    project_id = creds.project_id
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/creators/{user_id}"
+    resp = await asyncio.to_thread(rest_session.get, url)
+    if resp.status_code == 200:
+        data = _decode_document(resp.json())
+        return data.get("isApproved", True) is True
+    return False
+
 
 @app.get("/admin/dashboard")
 async def admin_dashboard(userId: str = Query(...)):
@@ -2718,3 +2848,125 @@ async def admin_ban_user(payload: dict = Body(...)):
     patch = {"fields": _encode_fields({"banned": True})}
     await asyncio.to_thread(rest_session.patch, url, json=patch)
     return {"status": "banned"}
+
+
+@app.get("/admin/ugc-analytics")
+async def admin_ugc_analytics(userId: str = Query(...), week: str = Query(None)):
+    if not await _verify_admin(userId):
+        return JSONResponse(status_code=403, content={"error": "Access denied"})
+    if not week:
+        week = datetime.utcnow().strftime("%Y-%W")
+    project_id = creds.project_id
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/ugc_analytics/{week}"
+    resp = await asyncio.to_thread(rest_session.get, url)
+    if resp.status_code != 200:
+        return {}
+    return _decode_document(resp.json())
+
+
+@app.post("/submit-featured-quest")
+async def submit_featured_quest(request: Request, payload: dict = Body(...)):
+    """Allow approved creators to submit a featured quest draft."""
+    uid = await _verify_token(request.headers.get("Authorization"))
+    if not uid or uid != payload.get("uid"):
+        return JSONResponse(status_code=401, content={"error": "unauthorized"})
+    if not await _verify_creator(uid):
+        return JSONResponse(status_code=403, content={"error": "not_creator"})
+
+    project_id = creds.project_id
+    quest_id = hashlib.sha1(f"{uid}-{datetime.utcnow()}".encode()).hexdigest()[:16]
+    quest_doc = {
+        "title": payload.get("title") or "Untitled Quest",
+        "questText": payload.get("questText", ""),
+        "locationList": payload.get("locationList", []),
+        "mood": payload.get("mood", ""),
+        "imageUrl": payload.get("imageUrl"),
+        "submittedBy": uid,
+        "createdAt": datetime.utcnow().isoformat(),
+        "isApproved": False,
+        "adminReviewed": False,
+        "tags": payload.get("tags", []),
+        "remixable": bool(payload.get("remixable", True)),
+        "stats": {"completions": 0, "remixes": 0},
+    }
+    url = (
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/featured_quests/{quest_id}"
+    )
+    body = {"fields": _encode_fields(quest_doc)}
+    resp = await asyncio.to_thread(rest_session.patch, url, json=body)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+
+    creator_url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/creators/{uid}"
+    cresp = await asyncio.to_thread(rest_session.get, creator_url)
+    if cresp.status_code == 200:
+        data = _decode_document(cresp.json())
+        ids = data.get("featuredQuestIds", [])
+        if quest_id not in ids:
+            ids.append(quest_id)
+            patch = {"fields": _encode_fields({"featuredQuestIds": ids})}
+            await asyncio.to_thread(rest_session.patch, creator_url, json=patch)
+
+    return {"questId": quest_id}
+
+
+@app.get("/featured-quests")
+async def get_featured_quests(approved: bool = Query(True)):
+    """Return featured quests optionally filtered by approval."""
+    project_id = creds.project_id
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/featured_quests:runQuery"
+    query = {
+        "structuredQuery": {
+            "from": [{"collectionId": "featured_quests"}],
+            "orderBy": [{"field": {"fieldPath": "createdAt"}, "direction": "DESCENDING"}],
+        }
+    }
+    if approved is not None:
+        query["structuredQuery"]["where"] = {
+            "fieldFilter": {
+                "field": {"fieldPath": "isApproved"},
+                "op": "EQUAL",
+                "value": {"booleanValue": approved},
+            }
+        }
+    resp = await asyncio.to_thread(rest_session.post, url, json=query)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+    raw = resp.json()
+    quests = []
+    for item in raw:
+        doc = item.get("document")
+        if not doc:
+            continue
+        obj = _decode_document(doc)
+        obj["id"] = doc["name"].split("/")[-1]
+        quests.append(obj)
+    return {"quests": quests}
+
+
+@app.get("/admin/featured-pending")
+async def admin_featured_pending(userId: str = Query(...)):
+    if not await _verify_admin(userId):
+        return JSONResponse(status_code=403, content={"error": "Access denied"})
+    return await get_featured_quests(approved=False)
+
+
+@app.post("/admin/review-featured-quest")
+async def admin_review_featured(payload: dict = Body(...)):
+    user_id = payload.get("userId")
+    quest_id = payload.get("questId")
+    approved = payload.get("approved", True)
+    if not await _verify_admin(user_id):
+        return JSONResponse(status_code=403, content={"error": "Access denied"})
+    if not quest_id:
+        return {"error": "questId required"}
+    project_id = creds.project_id
+    url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/featured_quests/{quest_id}"
+    patch = {"fields": _encode_fields({"isApproved": bool(approved), "adminReviewed": True})}
+    resp = await asyncio.to_thread(rest_session.patch, url, json=patch)
+    if resp.status_code != 200:
+        print("Firestore REST error", resp.text)
+        resp.raise_for_status()
+    return {"status": "updated"}

--- a/firestore.rules
+++ b/firestore.rules
@@ -71,6 +71,40 @@ service cloud.firestore {
       allow read, write: if request.auth != null && request.auth.uid == userId && !isBanned();
     }
 
+    // ===== UGC Submissions =====
+    match /ugc_submissions/{id} {
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.uid && !isBanned();
+      allow read, delete: if isAdmin();
+    }
+
+    match /ugc_feed/{id} {
+      allow read: if true;
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.uid && !isBanned();
+      allow update, delete: if isAdmin();
+    }
+
+    match /featured_quests/{questId} {
+      allow read: if resource.data.isApproved == true || isAdmin() ||
+                   (request.auth != null && request.auth.uid == resource.data.submittedBy);
+      allow create: if request.auth != null && request.auth.uid == request.resource.data.submittedBy && !isBanned();
+      allow update: if isAdmin();
+      allow delete: if isAdmin();
+    }
+
+    match /creators/{uid} {
+      allow read: if request.auth != null && (request.auth.uid == uid || isAdmin());
+      allow write: if isAdmin();
+    }
+
+    match /ugc_analytics/{doc} {
+      allow read, write: if isAdmin();
+    }
+
+    match /config/ugcWeeklyTag {
+      allow read: if true;
+      allow write: if isAdmin();
+    }
+
     // ===== Admin Config =====
     match /config/admins {
       allow read, write: if isAdmin();

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -21,6 +21,7 @@ import Pricing from "./pages/Pricing";
 import PaymentSuccess from "./components/PaymentSuccess";
 import PaymentFailed from "./components/PaymentFailed";
 import CommunityFeed from "./components/CommunityFeed";
+import UGCFeed from "./pages/UGCFeed";
 import CommunityPage from "./components/CommunityPage";
 import CreateCommunity from "./components/CreateCommunity";
 import AdminDashboard from "./components/AdminDashboard";
@@ -31,6 +32,12 @@ import Explore from "./components/Explore";
 import GroupQuestView from "./components/GroupQuestView";
 import Terms from "./pages/Terms";
 import Privacy from "./pages/Privacy";
+import UGCSubmitForm from "./components/UGCSubmitForm";
+import CreatorDashboard from "./pages/CreatorDashboard";
+import CreatorSubmitQuest from "./pages/CreatorSubmitQuest";
+import Featured from "./pages/Featured";
+import UGCAnalytics from "./pages/admin/UGCAnalytics";
+import FeaturedReview from "./pages/admin/FeaturedReview";
 import CookieConsent from "react-cookie-consent";
 
 
@@ -87,6 +94,7 @@ function App() {
         <Route path="/community" element={<CommunityFeed />} />
         <Route path="/community/new" element={<CreateCommunity />} />
         <Route path="/community/:id" element={<CommunityPage />} />
+        <Route path="/ugc-feed" element={<UGCFeed />} />
         <Route path="/explore" element={<Explore />} />
         <Route path="/admin" element={<AdminDashboard />} />
         <Route path="/quest-plus" element={<Pricing />} />
@@ -97,6 +105,12 @@ function App() {
         <Route path="/tag-editor/:questId" element={<TagEditor />} />
         <Route path="/terms" element={<Terms />} />
         <Route path="/privacy" element={<Privacy />} />
+        <Route path="/creator-dashboard" element={<CreatorDashboard />} />
+        <Route path="/creator-dashboard/submit-quest" element={<CreatorSubmitQuest />} />
+        <Route path="/featured" element={<Featured />} />
+        <Route path="/admin/ugc-analytics" element={<UGCAnalytics />} />
+        <Route path="/admin/featured-review" element={<FeaturedReview />} />
+        <Route path="/ugc-submit" element={<UGCSubmitForm />} />
         <Route path="/payment-success" element={<PaymentSuccess />} />
         <Route path="/payment-failed" element={<PaymentFailed />} />
       </Routes>

--- a/frontend/src/components/Header.jsx
+++ b/frontend/src/components/Header.jsx
@@ -2,17 +2,28 @@
 import React, { useEffect, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { getAuth, onAuthStateChanged } from "firebase/auth";
+import { doc, getDoc } from "firebase/firestore";
+import { db } from "../firebase";
 
 const Header = () => {
   const { pathname } = useLocation();
   const [isAdmin, setIsAdmin] = useState(false);
+  const [isCreator, setIsCreator] = useState(false);
   const [user, setUser] = useState(null);
 
   useEffect(() => {
     const auth = getAuth();
-    return onAuthStateChanged(auth, (u) => {
+    return onAuthStateChanged(auth, async (u) => {
       setUser(u);
-      setIsAdmin(u?.email === 'admin@roamio.app');
+      if (u) {
+        const snap = await getDoc(doc(db, 'users', u.uid));
+        const data = snap.exists() ? snap.data() : {};
+        setIsAdmin(Boolean(data.isAdmin));
+        setIsCreator(Boolean(data.isCreator));
+      } else {
+        setIsAdmin(false);
+        setIsCreator(false);
+      }
     });
   }, []);
 
@@ -31,13 +42,22 @@ const Header = () => {
         <Link to="/explore" className={linkClass("/explore")}>Explore</Link>
         <Link to="/history" className={linkClass("/history")}>History</Link>
         <Link to="/community" className={linkClass("/community")}>Community</Link>
+        <Link to="/ugc-feed" className={linkClass("/ugc-feed")}>UGC Feed</Link>
+        <Link to="/featured" className={linkClass("/featured")}>Featured</Link>
         <Link to="/community/new" className={linkClass("/community/new")}>New Community</Link>
         {user && (
           <Link to="/custom" className={linkClass("/custom")}>➕ Custom Quest</Link>
         )}
         <Link to="/pricing" className={linkClass("/pricing")}>Quest+</Link>
+        {isCreator && (
+          <Link to="/creator-dashboard" className={linkClass("/creator-dashboard")}>Creator</Link>
+        )}
         {isAdmin && (
-          <Link to="/admin" className={linkClass("/admin")}>Admin</Link>
+          <>
+            <Link to="/admin" className={linkClass("/admin")}>Admin</Link>
+            <Link to="/admin/ugc-analytics" className={linkClass("/admin/ugc-analytics")}>UGC</Link>
+            <Link to="/admin/featured-review" className={linkClass("/admin/featured-review")}>Review</Link>
+          </>
         )}
         {user && (
           <Link to="/profile" className={linkClass("/profile")}>Profile</Link>

--- a/frontend/src/components/PostcardCard.jsx
+++ b/frontend/src/components/PostcardCard.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+
+export default function PostcardCard({ post }) {
+  const {
+    imageUrl,
+    displayName,
+    city,
+    badgesUnlocked = [],
+    xpEarned,
+    mood,
+    questTitle,
+    timestamp,
+  } = post;
+  return (
+    <div className="bg-white rounded shadow overflow-hidden text-sm">
+      <img src={imageUrl || 'https://placehold.co/400'} alt="postcard" className="w-full h-40 object-cover" />
+      <div className="p-3 space-y-1">
+        <h3 className="font-semibold">{questTitle || 'Quest'}</h3>
+        <p className="text-gray-600">
+          {displayName && <span>By {displayName} </span>}
+          {city && <span className="text-xs">in {city}</span>}
+        </p>
+        <p className="text-xs text-gray-500">{mood}</p>
+        <p className="text-xs text-gray-500">{new Date(timestamp).toLocaleString()}</p>
+        <p className="text-xs">XP: {xpEarned}</p>
+        {badgesUnlocked.length > 0 && (
+          <div className="flex gap-1 flex-wrap">
+            {badgesUnlocked.map((b) => (
+              <span key={b} className="text-xs bg-yellow-100 px-1 rounded">
+                {b}
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Profile.jsx
+++ b/frontend/src/components/Profile.jsx
@@ -13,7 +13,12 @@ import {
 } from '../lib/api';
 import XPProgressBar from './XPProgressBar';
 import BadgeGallery from './BadgeGallery';
-import { setShowRoamioWatermark } from '../lib/firebase';
+import {
+  setShowRoamioWatermark,
+  setPublicSharingOptIn,
+  setShowUsernameOnShare,
+  setShowCityOnShare,
+} from '../lib/firebase';
 const LEVEL_THRESHOLDS = [0,50,120,200,300,420,550,700,880,1080];
 
 const Profile = () => {
@@ -25,6 +30,9 @@ const Profile = () => {
   const [level, setLevel] = useState(1);
   const [badges, setBadges] = useState([]);
   const [showWatermark, setShowWatermark] = useState(true);
+  const [publicOptIn, setPublicOptIn] = useState(false);
+  const [showName, setShowName] = useState(true);
+  const [showCity, setShowCity] = useState(true);
   const nextThreshold = LEVEL_THRESHOLDS[Math.min(level, LEVEL_THRESHOLDS.length - 1)];
 
   useEffect(() => {
@@ -43,6 +51,9 @@ const Profile = () => {
           setLevel(xpData.level || 1);
           setBadges(xpData.badgesUnlocked || []);
           setShowWatermark(xpData.showRoamioWatermark !== false);
+          setPublicOptIn(xpData.publicSharingOptIn === true);
+          setShowName(xpData.showUsernameOnShare !== false);
+          setShowCity(xpData.showCityOnShare !== false);
         } catch (err) {
           console.error('load xp error', err);
         }
@@ -135,6 +146,43 @@ const Profile = () => {
             }}
           />
           Watermark shared postcards with "Made with Roamio"
+        </label>
+      </div>
+
+      <div className="mb-8 space-y-2">
+        <h2 className="text-xl font-bold mb-1">Sharing Preferences</h2>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={publicOptIn}
+            onChange={async (e) => {
+              setPublicOptIn(e.target.checked);
+              if (user) await setPublicSharingOptIn(user.uid, e.target.checked);
+            }}
+          />
+          Allow others to see my shared quests
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={showName}
+            onChange={async (e) => {
+              setShowName(e.target.checked);
+              if (user) await setShowUsernameOnShare(user.uid, e.target.checked);
+            }}
+          />
+          Display my name on public shares
+        </label>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            checked={showCity}
+            onChange={async (e) => {
+              setShowCity(e.target.checked);
+              if (user) await setShowCityOnShare(user.uid, e.target.checked);
+            }}
+          />
+          Display my city/location on public shares
         </label>
       </div>
 

--- a/frontend/src/components/QuestCard.jsx
+++ b/frontend/src/components/QuestCard.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function QuestCard({ quest }) {
+  const { title, mood, imageUrl, tags = [] } = quest;
+  return (
+    <div className="flex gap-4 bg-white p-4 rounded shadow text-sm">
+      <img src={imageUrl || 'https://placehold.co/200'} alt="" className="w-32 h-20 object-cover rounded" />
+      <div className="flex-1">
+        <h3 className="font-semibold">{title || 'Quest'}</h3>
+        <p className="text-gray-600">{mood}</p>
+        {tags.length > 0 && (
+          <p className="text-xs text-gray-500">{tags.map((t) => `#${t}`).join(' ')}</p>
+        )}
+        <p className="text-xs mt-1">Creator Quest</p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/QuestLivePage.jsx
+++ b/frontend/src/components/QuestLivePage.jsx
@@ -40,6 +40,9 @@ export default function QuestLivePage() {
   const [shareOpen, setShareOpen] = useState(false);
   const [skipSharePrompt, setSkipSharePromptState] = useState(false);
   const [showWatermark, setShowWatermark] = useState(true);
+  const [publicOptIn, setPublicOptIn] = useState(false);
+  const [showName, setShowName] = useState(true);
+  const [showCity, setShowCity] = useState(true);
   const [etaText, setEtaText] = useState("");
   const [etaError, setEtaError] = useState("");
   const [etaRefresh, setEtaRefresh] = useState(0);
@@ -59,6 +62,9 @@ export default function QuestLivePage() {
           setBadges(data.badges || {});
           setSkipSharePromptState(!!data.skipSharePrompt);
           setShowWatermark(data.showRoamioWatermark !== false);
+          setPublicOptIn(!!data.publicSharingOptIn);
+          setShowName(data.showUsernameOnShare !== false);
+          setShowCity(data.showCityOnShare !== false);
         }
       })
       .catch((e) => console.error('user fetch error', e));
@@ -341,10 +347,13 @@ export default function QuestLivePage() {
     setSaving(true);
     setCompleteMsg("");
     try {
-      const share = window.confirm('Share this quest publicly?');
+      let share = publicOptIn;
+      if (!publicOptIn) {
+        share = window.confirm('Share this quest publicly?');
+      }
       const res = await completeQuest(user.uid, questId, {
         title: quest.title,
-        city: quest.city,
+        city: showCity ? quest.city : null,
         mood: quest.mood,
         difficulty: quest.difficulty,
         questText: quest.questText,
@@ -353,7 +362,9 @@ export default function QuestLivePage() {
         visitedIndices,
         isDemo: questId.startsWith('demo_'),
         public: share,
-        displayName: user.displayName,
+        displayName: showName ? user.displayName : null,
+        shareName: showName,
+        shareCity: showCity,
       });
       if (groupId) {
         await completeGroupQuest(groupId, user.uid);

--- a/frontend/src/components/UGCSubmitForm.jsx
+++ b/frontend/src/components/UGCSubmitForm.jsx
@@ -1,0 +1,71 @@
+import React, { useEffect, useState } from 'react';
+import { getAuth } from 'firebase/auth';
+import { fetchWeeklyTagConfig } from '../lib/xpBoostHelpers';
+import { submitUGC } from '../lib/api';
+import { toast } from '../lib/toast';
+
+export default function UGCSubmitForm() {
+  const [tag, setTag] = useState('');
+  const [platform, setPlatform] = useState('Instagram');
+  const [multiplier, setMultiplier] = useState(1);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    (async () => {
+      const cfg = await fetchWeeklyTagConfig();
+      if (cfg.activeTag) setTag(cfg.activeTag);
+      if (cfg.xpMultiplier) setMultiplier(cfg.xpMultiplier);
+    })();
+  }, []);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user) return toast('Login required');
+    setLoading(true);
+    try {
+      await submitUGC({ uid: user.uid, tag, platform });
+      toast(`Great! Your next quest will earn ${multiplier}x XP!`);
+    } catch (err) {
+      console.error('ugc submit failed', err);
+      toast('Submission failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-[#f8fcf8] p-6 text-[#0e1b0e]">
+      <h1 className="text-xl font-bold mb-4">Share Your Quest</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+        <div>
+          <label className="block text-sm mb-1">Platform</label>
+          <select
+            className="border rounded p-2 w-full"
+            value={platform}
+            onChange={(e) => setPlatform(e.target.value)}
+          >
+            <option>Instagram</option>
+            <option>Twitter</option>
+            <option>TikTok</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Tag</label>
+          <input
+            className="border rounded p-2 w-full"
+            value={tag}
+            onChange={(e) => setTag(e.target.value)}
+          />
+        </div>
+        <button
+          className="w-full bg-blue-600 text-white py-2 rounded"
+          disabled={loading}
+        >
+          {loading ? 'Submitting...' : 'Submit'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -231,6 +231,17 @@ export async function getCommunityQuests() {
   return resp.json();
 }
 
+export async function getUGCFeed({ mood, city } = {}) {
+  const url = new URL(`${BASE_URL}/ugc-feed`);
+  if (mood) url.searchParams.set('mood', mood);
+  if (city) url.searchParams.set('city', city);
+  const resp = await fetch(url.toString());
+  if (!resp.ok) {
+    throw new Error('Failed to load UGC feed');
+  }
+  return resp.json();
+}
+
 export async function reportQuest(userId, questId, reason, city, mood) {
   const resp = await fetch(`${BASE_URL}/report-quest`, {
     method: 'POST',
@@ -550,6 +561,60 @@ export async function banUser(userId, targetId) {
     body: JSON.stringify({ userId, targetId })
   });
   if (!resp.ok) throw new Error('Failed to ban user');
+  return resp.json();
+}
+
+export async function submitUGC(payload) {
+  const auth = getAuth();
+  const user = auth.currentUser;
+  if (!user) throw new Error('Auth required');
+  const token = await user.getIdToken();
+  const resp = await fetch(`${BASE_URL}/ugc-submit`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(payload)
+  });
+  if (!resp.ok) throw new Error('Failed to submit');
+  return resp.json();
+}
+
+export async function submitFeaturedQuest(payload) {
+  const auth = getAuth();
+  const user = auth.currentUser;
+  if (!user) throw new Error('Auth required');
+  const token = await user.getIdToken();
+  const resp = await fetch(`${BASE_URL}/submit-featured-quest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body: JSON.stringify(payload)
+  });
+  if (!resp.ok) throw new Error('Failed to submit quest');
+  return resp.json();
+}
+
+export async function getFeaturedQuests(approved = true) {
+  const url = new URL(`${BASE_URL}/featured-quests`);
+  if (approved !== null) url.searchParams.set('approved', approved);
+  const resp = await fetch(url.toString());
+  if (!resp.ok) throw new Error('Failed to load featured quests');
+  return resp.json();
+}
+
+export async function listPendingFeatured(userId) {
+  const url = new URL(`${BASE_URL}/admin/featured-pending`);
+  url.searchParams.set('userId', userId);
+  const resp = await fetch(url.toString());
+  if (!resp.ok) throw new Error('Failed to load pending quests');
+  return resp.json();
+}
+
+export async function reviewFeaturedQuest(userId, questId, approved = true) {
+  const resp = await fetch(`${BASE_URL}/admin/review-featured-quest`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ userId, questId, approved })
+  });
+  if (!resp.ok) throw new Error('Failed to update quest');
   return resp.json();
 }
 

--- a/frontend/src/lib/firebase.js
+++ b/frontend/src/lib/firebase.js
@@ -28,14 +28,21 @@ export async function guestLogin() {
   const res = await signInAnonymously(auth);
   return res.user;
 }
-import { doc, updateDoc } from 'firebase/firestore';
+import {
+  doc,
+  updateDoc,
+  getDoc,
+  collection,
+  query,
+  where,
+  getDocs,
+} from 'firebase/firestore';
 import { db } from '../firebase';
 
 export async function updateUserBadges(userId, badges) {
   if (!userId) return;
   await updateDoc(doc(db, 'users', userId), { badges });
 }
-import { getDoc } from 'firebase/firestore';
 
 export async function getUserSettings(userId) {
   if (!userId) return {};
@@ -51,4 +58,37 @@ export async function setShowRoamioWatermark(userId, value) {
 export async function setSkipSharePrompt(userId, value) {
   if (!userId) return;
   await updateDoc(doc(db, 'users', userId), { skipSharePrompt: value });
+}
+
+export async function setUGCBoostActive(userId, value) {
+  if (!userId) return;
+  await updateDoc(doc(db, 'users', userId), { ugcBoostActive: value });
+}
+
+export async function getCreatorProfile(uid) {
+  if (!uid) return null;
+  const snap = await getDoc(doc(db, 'creators', uid));
+  return snap.exists() ? snap.data() : null;
+}
+
+export async function getUserUGCSubmissions(uid) {
+  if (!uid) return [];
+  const q = query(collection(db, 'ugc_submissions'), where('uid', '==', uid));
+  const snap = await getDocs(q);
+  return snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+}
+
+export async function setPublicSharingOptIn(uid, val) {
+  if (!uid) return;
+  await updateDoc(doc(db, 'users', uid), { publicSharingOptIn: val });
+}
+
+export async function setShowUsernameOnShare(uid, val) {
+  if (!uid) return;
+  await updateDoc(doc(db, 'users', uid), { showUsernameOnShare: val });
+}
+
+export async function setShowCityOnShare(uid, val) {
+  if (!uid) return;
+  await updateDoc(doc(db, 'users', uid), { showCityOnShare: val });
 }

--- a/frontend/src/lib/ugcUtils.js
+++ b/frontend/src/lib/ugcUtils.js
@@ -1,0 +1,30 @@
+import { getCreatorProfile, getUserUGCSubmissions } from './firebase';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export async function fetchCreatorStats(uid) {
+  const profile = await getCreatorProfile(uid);
+  const submissions = await getUserUGCSubmissions(uid);
+  return { profile, submissions };
+}
+
+export async function fetchUGCAnalytics(week) {
+  if (!week) return null;
+  const snap = await getDoc(doc(db, 'ugc_analytics', week));
+  return snap.exists() ? snap.data() : null;
+}
+
+export function exportAnalyticsCsv(data) {
+  if (!data || !data.topContributors) return;
+  const rows = data.topContributors.map((c) =>
+    [c.uid, c.displayName, c.submissionCount].join(',')
+  );
+  const csv = ['uid,displayName,submissionCount', ...rows].join('\n');
+  const blob = new Blob([csv], { type: 'text/csv' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = 'ugc-analytics.csv';
+  a.click();
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/lib/xpBoostHelpers.js
+++ b/frontend/src/lib/xpBoostHelpers.js
@@ -1,0 +1,11 @@
+export function applyXPBoost(xp, multiplier = 1) {
+  return Math.round(xp * multiplier);
+}
+
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export async function fetchWeeklyTagConfig() {
+  const snap = await getDoc(doc(db, 'config', 'ugcWeeklyTag'));
+  return snap.exists() ? snap.data() : {};
+}

--- a/frontend/src/pages/CreatorDashboard.jsx
+++ b/frontend/src/pages/CreatorDashboard.jsx
@@ -1,0 +1,70 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getAuth } from 'firebase/auth';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+import { fetchCreatorStats } from '../lib/ugcUtils';
+
+export default function CreatorDashboard() {
+  const [stats, setStats] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user) return navigate('/');
+    (async () => {
+      const snap = await getDoc(doc(db, 'users', user.uid));
+      if (!snap.exists() || !snap.data().isCreator) {
+        navigate('/');
+        return;
+      }
+      const data = await fetchCreatorStats(user.uid);
+      setStats(data);
+      setLoading(false);
+    })();
+  }, [navigate]);
+
+  if (loading) return <div className="p-6">Loading...</div>;
+  if (!stats) return <div className="p-6">No data</div>;
+
+  const { profile, submissions } = stats;
+
+  return (
+    <div className="p-6 text-[#0e1b0e] space-y-4">
+      <h1 className="text-2xl font-bold">Creator Dashboard</h1>
+      <div className="grid md:grid-cols-3 gap-4">
+        <div className="bg-white p-4 rounded shadow">
+          <p className="text-xs text-gray-500">Total Submissions</p>
+          <p className="text-xl font-bold">{profile?.totalSubmissions || submissions.length}</p>
+        </div>
+        <div className="bg-white p-4 rounded shadow">
+          <p className="text-xs text-gray-500">Quest Shares</p>
+          <p className="text-xl font-bold">{profile?.totalQuestShares || 0}</p>
+        </div>
+        <div className="bg-white p-4 rounded shadow">
+          <p className="text-xs text-gray-500">Creator Level</p>
+          <p className="text-xl font-bold capitalize">{profile?.creatorLevel || 'bronze'}</p>
+        </div>
+      </div>
+      <div>
+        <h2 className="font-semibold mt-4 mb-2">Your Submissions</h2>
+        <ul className="space-y-2">
+          {submissions.map((s) => (
+            <li key={s.id} className="border p-2 rounded text-sm flex justify-between">
+              <span>#{s.tag} – {s.platform}</span>
+              <span>{new Date(s.timestamp).toLocaleDateString()}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+      <button
+        onClick={() => navigate('/creator-dashboard/submit-quest')}
+        className="bg-blue-600 text-white px-3 py-2 rounded"
+      >
+        Submit Featured Quest
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/CreatorSubmitQuest.jsx
+++ b/frontend/src/pages/CreatorSubmitQuest.jsx
@@ -1,0 +1,71 @@
+import React, { useState } from 'react';
+import { getAuth } from 'firebase/auth';
+import { useNavigate } from 'react-router-dom';
+import { submitFeaturedQuest } from '../lib/api';
+import { toast } from '../lib/toast';
+
+export default function CreatorSubmitQuest() {
+  const [title, setTitle] = useState('');
+  const [mood, setMood] = useState('');
+  const [questText, setQuestText] = useState('');
+  const [locations, setLocations] = useState('');
+  const [tags, setTags] = useState('');
+  const [loading, setLoading] = useState(false);
+  const navigate = useNavigate();
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user) return toast('Login required');
+    setLoading(true);
+    try {
+      await submitFeaturedQuest({
+        uid: user.uid,
+        title,
+        mood,
+        questText,
+        locationList: locations.split(',').map((s) => s.trim()).filter(Boolean),
+        tags: tags.split(',').map((s) => s.trim()).filter(Boolean),
+      });
+      toast('Quest submitted for review');
+      navigate('/creator-dashboard');
+    } catch (err) {
+      console.error('submit failed', err);
+      toast('Failed to submit');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-xl font-bold">Submit Featured Quest</h1>
+      <form onSubmit={handleSubmit} className="space-y-4 max-w-md">
+        <div>
+          <label className="block text-sm mb-1">Title</label>
+          <input className="border rounded w-full p-2" value={title} onChange={(e) => setTitle(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Mood</label>
+          <input className="border rounded w-full p-2" value={mood} onChange={(e) => setMood(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Quest Text</label>
+          <textarea className="border rounded w-full p-2" value={questText} onChange={(e) => setQuestText(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Places (comma-separated)</label>
+          <input className="border rounded w-full p-2" value={locations} onChange={(e) => setLocations(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm mb-1">Tags (comma-separated)</label>
+          <input className="border rounded w-full p-2" value={tags} onChange={(e) => setTags(e.target.value)} />
+        </div>
+        <button className="bg-blue-600 text-white px-4 py-2 rounded w-full" disabled={loading}>
+          {loading ? 'Submitting...' : 'Submit'}
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/frontend/src/pages/Featured.jsx
+++ b/frontend/src/pages/Featured.jsx
@@ -1,0 +1,35 @@
+import React, { useEffect, useState } from 'react';
+import QuestCard from '../components/QuestCard';
+import { getFeaturedQuests } from '../lib/api';
+
+export default function Featured() {
+  const [quests, setQuests] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await getFeaturedQuests(true);
+        setQuests(data.quests || []);
+      } catch (e) {
+        console.error('failed to load', e);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, []);
+
+  if (loading) return <div className="p-6">Loading...</div>;
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-2xl font-bold">Featured Quests</h1>
+      {quests.length === 0 && <p>No featured quests yet.</p>}
+      <div className="space-y-4">
+        {quests.map((q) => (
+          <QuestCard key={q.id} quest={q} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/UGCFeed.jsx
+++ b/frontend/src/pages/UGCFeed.jsx
@@ -1,0 +1,54 @@
+import React, { useEffect, useState } from 'react';
+import PostcardCard from '../components/PostcardCard';
+import { getUGCFeed } from '../lib/api';
+
+export default function UGCFeed() {
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [mood, setMood] = useState('');
+  const [city, setCity] = useState('');
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const data = await getUGCFeed({ mood, city });
+        setPosts(data.posts || []);
+      } catch (err) {
+        console.error('Failed to load feed', err);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [mood, city]);
+
+  if (loading) return <div className="p-6">Loading...</div>;
+  return (
+    <div className="min-h-screen bg-[#f8fcf8] p-6 text-[#0e1b0e]">
+      <h1 className="text-2xl font-bold mb-4">UGC Feed</h1>
+      <div className="mb-4 flex gap-4">
+        <select
+          value={mood}
+          onChange={(e) => setMood(e.target.value)}
+          className="border rounded px-2 py-1"
+        >
+          <option value="">All Moods</option>
+          <option>Nature</option>
+          <option>History</option>
+          <option>Foodie</option>
+        </select>
+        <input
+          value={city}
+          onChange={(e) => setCity(e.target.value)}
+          placeholder="City"
+          className="border rounded px-2 py-1"
+        />
+      </div>
+      {posts.length === 0 && <p>No posts yet.</p>}
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
+        {posts.map((p) => (
+          <PostcardCard key={p.id} post={p} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/FeaturedReview.jsx
+++ b/frontend/src/pages/admin/FeaturedReview.jsx
@@ -1,0 +1,50 @@
+import React, { useEffect, useState } from 'react';
+import { getAuth } from 'firebase/auth';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '../../firebase';
+import QuestCard from '../../components/QuestCard';
+import { listPendingFeatured, reviewFeaturedQuest } from '../../lib/api';
+
+export default function FeaturedReview() {
+  const [quests, setQuests] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      const auth = getAuth();
+      const user = auth.currentUser;
+      if (!user) return;
+      const snap = await getDoc(doc(db, 'users', user.uid));
+      if (!snap.exists() || !snap.data().isAdmin) return;
+      const data = await listPendingFeatured(user.uid);
+      setQuests(data.quests || []);
+      setLoading(false);
+    })();
+  }, []);
+
+  const handleAction = async (questId, approved) => {
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user) return;
+    await reviewFeaturedQuest(user.uid, questId, approved);
+    setQuests((q) => q.filter((item) => item.id !== questId));
+  };
+
+  if (loading) return <div className="p-6">Loading...</div>;
+
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-xl font-bold">Review Featured Quests</h1>
+      {quests.map((q) => (
+        <div key={q.id} className="border p-4 rounded space-y-2">
+          <QuestCard quest={q} />
+          <div className="flex gap-2">
+            <button onClick={() => handleAction(q.id, true)} className="bg-green-600 text-white px-3 py-1 rounded text-sm">Approve</button>
+            <button onClick={() => handleAction(q.id, false)} className="bg-red-600 text-white px-3 py-1 rounded text-sm">Reject</button>
+          </div>
+        </div>
+      ))}
+      {quests.length === 0 && <p>No pending quests.</p>}
+    </div>
+  );
+}

--- a/frontend/src/pages/admin/UGCAnalytics.jsx
+++ b/frontend/src/pages/admin/UGCAnalytics.jsx
@@ -1,0 +1,85 @@
+import React, { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { getAuth } from 'firebase/auth';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '../../firebase';
+import { fetchWeeklyTagConfig } from '../../lib/xpBoostHelpers';
+import { fetchUGCAnalytics, exportAnalyticsCsv } from '../../lib/ugcUtils';
+
+export default function UGCAnalytics() {
+  const [config, setConfig] = useState(null);
+  const [analytics, setAnalytics] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user) return navigate('/');
+    (async () => {
+      const snap = await getDoc(doc(db, 'users', user.uid));
+      if (!snap.exists() || !snap.data().isAdmin) {
+        navigate('/');
+        return;
+      }
+      const cfg = await fetchWeeklyTagConfig();
+      const weekKey = cfg.startDate || '';
+      const data = await fetchUGCAnalytics(weekKey);
+      setConfig(cfg);
+      setAnalytics(data || {});
+      setLoading(false);
+    })();
+  }, [navigate]);
+
+  if (loading) return <div className="p-6">Loading...</div>;
+
+  const handleExport = () => {
+    exportAnalyticsCsv(analytics);
+  };
+
+  return (
+    <div className="p-6 text-[#0e1b0e] space-y-4">
+      <h1 className="text-2xl font-bold">UGC Analytics</h1>
+      {config && (
+        <div className="bg-white p-4 rounded shadow">
+          <p className="font-semibold">Active Tag: #{config.activeTag}</p>
+          <p className="text-sm">
+            {config.startDate} – {config.endDate}
+          </p>
+        </div>
+      )}
+      {analytics && (
+        <div className="space-y-4">
+          <div className="grid md:grid-cols-3 gap-4">
+            <div className="bg-white p-4 rounded shadow">
+              <p className="text-xs text-gray-500">Total Submissions</p>
+              <p className="text-xl font-bold">{analytics.totalSubmissions || 0}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <p className="text-xs text-gray-500">Unique Users</p>
+              <p className="text-xl font-bold">{analytics.uniqueUsers || 0}</p>
+            </div>
+            <div className="bg-white p-4 rounded shadow">
+              <p className="text-xs text-gray-500">Most Used Tag</p>
+              <p className="text-xl font-bold">#{analytics.mostUsedTag || ''}</p>
+            </div>
+          </div>
+          <div>
+            <h2 className="font-semibold mb-2">Top Contributors</h2>
+            <ul className="space-y-2">
+              {(analytics.topContributors || []).map((c) => (
+                <li key={c.uid} className="border p-2 rounded text-sm flex justify-between">
+                  <span>{c.displayName}</span>
+                  <span>{c.submissionCount}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <button onClick={handleExport} className="bg-blue-600 text-white px-3 py-2 rounded">
+            Export CSV
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add creator dashboard page and admin UGC analytics panel
- expose creator profile and submission helpers
- surface creator and admin links in header
- secure Firestore collections for creators and analytics
- backend endpoint to fetch analytics snapshots
- add public UGC feed and sharing preferences
- add featured quest publishing tools

## Testing
- `node tests/firestoreRules.test.js` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_6882719e98fc8321a80ece73f7af6c88