### PR TITLE
Add mobile gamification screens

### DIFF
--- a/roamio-mobile/components/BadgesModal.jsx
+++ b/roamio-mobile/components/BadgesModal.jsx
@@ -1,0 +1,45 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { Modal, View, Text, FlatList, TouchableOpacity } from 'react-native';
+import { AppContext } from '../context/AppContext';
+import { collection, getDocs } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export default function BadgesModal({ visible, onClose }) {
+  const { user } = useContext(AppContext);
+  const [badges, setBadges] = useState([]);
+
+  useEffect(() => {
+    if (!visible || !user) return;
+    (async () => {
+      try {
+        const snap = await getDocs(collection(db, 'users', user.uid, 'badges'));
+        const arr = snap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        setBadges(arr);
+      } catch (err) {
+        console.log('badge load', err);
+      }
+    })();
+  }, [visible, user]);
+
+  return (
+    <Modal visible={visible} animationType="slide">
+      <View className="flex-1 p-4">
+        <TouchableOpacity onPress={onClose} className="mb-2">
+          <Text className="text-blue-600">Close</Text>
+        </TouchableOpacity>
+        <FlatList
+          data={badges}
+          numColumns={3}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <View className="flex-1 items-center m-2">
+              <Text className="text-2xl">{item.icon || '🎖️'}</Text>
+              <Text className="text-xs text-center">{item.id}</Text>
+            </View>
+          )}
+          ListEmptyComponent={<Text>No badges yet</Text>}
+        />
+      </View>
+    </Modal>
+  );
+}

--- a/roamio-mobile/context/AppContext.js
+++ b/roamio-mobile/context/AppContext.js
@@ -13,6 +13,7 @@ export function AppProvider({ children }) {
   const [quest, setQuest] = useState(null);
   const [isPremium, setIsPremium] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [showOnboarding, setShowOnboarding] = useState(false);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (u) => {
@@ -21,7 +22,11 @@ export function AppProvider({ children }) {
         try {
           const snap = await getDoc(doc(db, 'users', u.uid));
           if (snap.exists()) {
-            setIsPremium(snap.data().premium === true);
+            const data = snap.data();
+            setIsPremium(data.premium === true);
+            setShowOnboarding(data.onboardingComplete !== true);
+          } else {
+            setShowOnboarding(true);
           }
           await registerForPushNotifications();
         } catch (err) {
@@ -36,6 +41,7 @@ export function AppProvider({ children }) {
       } else {
         setIsPremium(false);
         setQuest(null);
+        setShowOnboarding(false);
         await AsyncStorage.removeItem('currentQuest');
       }
       setLoading(false);
@@ -59,7 +65,17 @@ export function AppProvider({ children }) {
   }, [quest]);
 
   return (
-    <AppContext.Provider value={{ user, quest, setQuest, isPremium, loading }}>
+    <AppContext.Provider
+      value={{
+        user,
+        quest,
+        setQuest,
+        isPremium,
+        loading,
+        showOnboarding,
+        setShowOnboarding,
+      }}
+    >
       {children}
     </AppContext.Provider>
   );

--- a/roamio-mobile/lib/progress.js
+++ b/roamio-mobile/lib/progress.js
@@ -34,12 +34,18 @@ export async function completeQuest(quest) {
     visitedIndices: quest.visitedIndices || [],
   };
   try {
-    await fetch(`${BASE_URL}/quest-complete`, {
+    const res = await fetch(`${BASE_URL}/quest-complete`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(payload),
     });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(text);
+    }
+    return await res.json();
   } catch (err) {
     console.log('Complete quest error', err);
+    return null;
   }
 }

--- a/roamio-mobile/navigation/MainNavigator.js
+++ b/roamio-mobile/navigation/MainNavigator.js
@@ -9,22 +9,32 @@ import SettingsScreen from '../screens/SettingsScreen';
 import CustomQuestScreen from '../screens/CustomQuestScreen';
 import CustomQuestBuilderScreen from '../screens/CustomQuestBuilderScreen';
 import MyQuestsScreen from '../screens/MyQuestsScreen';
+import QuestCompleteScreen from '../screens/QuestCompleteScreen';
+import QuestHistoryScreen from '../screens/QuestHistoryScreen';
+import LeaderboardScreen from '../screens/LeaderboardScreen';
+import OnboardingFlow from '../screens/OnboardingFlow';
 import { AppContext } from '../context/AppContext';
 
 const Stack = createNativeStackNavigator();
 
 export default function MainNavigator() {
-  const { user } = useContext(AppContext);
+  const { user, showOnboarding } = useContext(AppContext);
   return (
     <Stack.Navigator>
       {user ? (
         <>
+          {showOnboarding && (
+            <Stack.Screen name="Onboarding" component={OnboardingFlow} options={{ headerShown: false }} />
+          )}
           <Stack.Screen name="Home" component={HomeScreen} options={{ headerShown: false }} />
           <Stack.Screen name="QuestLive" component={QuestLiveScreen} options={{ title: 'Quest' }} />
+          <Stack.Screen name="QuestComplete" component={QuestCompleteScreen} options={{ title: 'Quest Complete' }} />
           <Stack.Screen name="GroupQuest" component={GroupQuestScreen} options={{ title: 'Group Quest' }} />
           <Stack.Screen name="CustomQuest" component={CustomQuestScreen} options={{ title: 'Custom Quest' }} />
           <Stack.Screen name="CustomQuestBuilder" component={CustomQuestBuilderScreen} options={{ title: 'Build Quest' }} />
           <Stack.Screen name="MyQuests" component={MyQuestsScreen} options={{ title: 'My Quests' }} />
+          <Stack.Screen name="QuestHistory" component={QuestHistoryScreen} options={{ title: 'Quest History' }} />
+          <Stack.Screen name="Leaderboard" component={LeaderboardScreen} options={{ title: 'Leaderboards' }} />
           <Stack.Screen name="Profile" component={ProfileScreen} />
           <Stack.Screen name="Settings" component={SettingsScreen} />
         </>

--- a/roamio-mobile/screens/LeaderboardScreen.jsx
+++ b/roamio-mobile/screens/LeaderboardScreen.jsx
@@ -1,0 +1,66 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, FlatList, TouchableOpacity, ActivityIndicator } from 'react-native';
+import Constants from 'expo-constants';
+import SharedHeader from '../components/SharedHeader';
+
+const BASE_URL = Constants.expoConfig.extra.backendUrl || 'http://localhost:8080';
+
+async function fetchLeaderboard({ type = 'xp', period = 'allTime', city } = {}) {
+  const docId = city ? `${type}_${city}_${period}` : `${type}_${period}`;
+  const res = await fetch(`${BASE_URL}/leaderboard-snapshot/${docId}`);
+  if (!res.ok) throw new Error('Failed to fetch leaderboard');
+  return res.json();
+}
+
+export default function LeaderboardScreen() {
+  const [entries, setEntries] = useState([]);
+  const [type, setType] = useState('xp');
+  const [period, setPeriod] = useState('allTime');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      setLoading(true);
+      try {
+        const data = await fetchLeaderboard({ type, period });
+        setEntries(data.entries || []);
+      } catch (err) {
+        console.log('lb fetch', err);
+      } finally {
+        setLoading(false);
+      }
+    })();
+  }, [type, period]);
+
+  return (
+    <View className="flex-1 p-4">
+      <SharedHeader title="Leaderboards" />
+      <View className="flex-row mb-2 space-x-2 justify-center">
+        <TouchableOpacity onPress={() => setType('xp')}>
+          <Text className={type === 'xp' ? 'font-bold' : ''}>XP</Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={() => setType('streaks')}>
+          <Text className={type === 'streaks' ? 'font-bold' : ''}>Streaks</Text>
+        </TouchableOpacity>
+        <TouchableOpacity onPress={() => setPeriod(period === 'allTime' ? 'weekly' : 'allTime')}>
+          <Text>{period === 'allTime' ? 'All Time' : 'This Week'}</Text>
+        </TouchableOpacity>
+      </View>
+      {loading ? (
+        <ActivityIndicator />
+      ) : (
+        <FlatList
+          data={entries}
+          keyExtractor={(item, idx) => item.uid || `${idx}`}
+          renderItem={({ item, index }) => (
+            <View className="flex-row justify-between border-b py-1">
+              <Text>#{index + 1} {item.displayName || 'Anon'}</Text>
+              <Text>{type === 'xp' ? `${item.xp} XP` : `${item.streakCount || 0} days`}</Text>
+            </View>
+          )}
+          ListEmptyComponent={<Text>No data</Text>}
+        />
+      )}
+    </View>
+  );
+}

--- a/roamio-mobile/screens/OnboardingFlow.jsx
+++ b/roamio-mobile/screens/OnboardingFlow.jsx
@@ -1,0 +1,54 @@
+import React, { useContext, useState } from 'react';
+import { View, Text, Button } from 'react-native';
+import { AppContext } from '../context/AppContext';
+import { doc, updateDoc } from 'firebase/firestore';
+import { db } from '../firebase';
+import SharedHeader from '../components/SharedHeader';
+
+const steps = [
+  {
+    title: 'Welcome',
+    text: "We aren't an app to keep you indoors. We get you moving. Start adventuring.",
+  },
+  {
+    title: 'How Quests Work',
+    text: 'Pick a mood and time limit, then follow the map to new spots.',
+  },
+  {
+    title: 'Progression',
+    text: 'Earn XP, maintain streaks and collect badges as you level up.',
+  },
+  {
+    title: 'Group Quests',
+    text: 'Quest with friends for bonus rewards and shared progress.',
+  },
+];
+
+export default function OnboardingFlow({ navigation }) {
+  const { user, setShowOnboarding } = useContext(AppContext);
+  const [index, setIndex] = useState(0);
+
+  const next = async () => {
+    if (index < steps.length - 1) {
+      setIndex(index + 1);
+    } else {
+      if (user) {
+        try {
+          await updateDoc(doc(db, 'users', user.uid), { onboardingComplete: true });
+        } catch (err) {
+          console.log('onboarding save', err);
+        }
+      }
+      setShowOnboarding(false);
+      navigation.replace('Home');
+    }
+  };
+
+  return (
+    <View className="flex-1 items-center justify-center p-4">
+      <SharedHeader title={steps[index].title} />
+      <Text className="mb-4 text-center">{steps[index].text}</Text>
+      <Button title={index === steps.length - 1 ? 'Start Adventuring' : 'Next'} onPress={next} />
+    </View>
+  );
+}

--- a/roamio-mobile/screens/ProfileScreen.jsx
+++ b/roamio-mobile/screens/ProfileScreen.jsx
@@ -1,18 +1,27 @@
 import React, { useContext, useEffect, useState } from 'react';
-import { View, Text, Image, FlatList, Button } from 'react-native';
+import { View, Text, Image, FlatList, Button, TouchableOpacity } from 'react-native';
 import SharedHeader from '../components/SharedHeader';
 import { AppContext } from '../context/AppContext';
-import { collection, getDocs } from 'firebase/firestore';
+import { collection, getDocs, doc, getDoc } from 'firebase/firestore';
 import { db } from '../firebase';
+import BadgesModal from '../components/BadgesModal';
 
 export default function ProfileScreen({ navigation }) {
   const { user } = useContext(AppContext);
   const [postcards, setPostcards] = useState([]);
+  const [profile, setProfile] = useState({ xp: 0, level: 0, streakCount: 0 });
+  const [badges, setBadges] = useState([]);
+  const [showModal, setShowModal] = useState(false);
 
   useEffect(() => {
     async function load() {
       if (!user) return;
       try {
+        const usnap = await getDoc(doc(db, 'users', user.uid));
+        if (usnap.exists()) setProfile(usnap.data());
+        const bSnap = await getDocs(collection(db, 'users', user.uid, 'badges'));
+        const bArr = bSnap.docs.map((d) => ({ id: d.id, ...d.data() }));
+        setBadges(bArr);
         const q = collection(db, 'user_quests', user.uid, 'quests');
         const snap = await getDocs(q);
         const arr = [];
@@ -31,6 +40,12 @@ export default function ProfileScreen({ navigation }) {
   return (
     <View className="flex-1 p-4 items-center">
       <SharedHeader title="Profile" />
+      <Text className="mt-2">XP: {profile.xp || 0}</Text>
+      <Text>Level: {profile.level || 0}</Text>
+      <Text>Streak: {profile.streakCount || 0} days</Text>
+      <TouchableOpacity onPress={() => setShowModal(true)} className="mb-2 mt-1">
+        <Text className="text-blue-600">View Badges</Text>
+      </TouchableOpacity>
       <FlatList
         data={postcards}
         numColumns={3}
@@ -43,6 +58,7 @@ export default function ProfileScreen({ navigation }) {
         }
       />
       <Button title="My Custom Quests" onPress={() => navigation.navigate('MyQuests')} />
+      <BadgesModal visible={showModal} onClose={() => setShowModal(false)} />
     </View>
   );
 }

--- a/roamio-mobile/screens/QuestCompleteScreen.jsx
+++ b/roamio-mobile/screens/QuestCompleteScreen.jsx
@@ -1,0 +1,34 @@
+import React, { useContext } from 'react';
+import { View, Text, Image, Button } from 'react-native';
+import SharedHeader from '../components/SharedHeader';
+import { AppContext } from '../context/AppContext';
+import { toast } from '../lib/toast';
+
+export default function QuestCompleteScreen({ route, navigation }) {
+  const { summary } = route.params || {};
+  const { user } = useContext(AppContext);
+
+  return (
+    <View className="flex-1 items-center p-4">
+      <SharedHeader title="Quest Complete" />
+      {summary?.imageUrl && (
+        <Image source={{ uri: summary.imageUrl }} className="w-48 h-48 mb-4" />
+      )}
+      <Text className="text-xl font-bold mb-2">+{summary?.xpEarned || 0} XP</Text>
+      <Text className="mb-1">Level {summary?.level}</Text>
+      {summary?.streakCount ? (
+        <Text className="mb-1">🔥 {summary.streakCount}-Day Streak!</Text>
+      ) : null}
+      {summary?.badgesUnlocked?.length > 0 && (
+        <View className="items-center mb-2">
+          <Text>You earned:</Text>
+          {summary.badgesUnlocked.map((b) => (
+            <Text key={b}>🎖️ {b}</Text>
+          ))}
+        </View>
+      )}
+      <Button title="Share Quest" onPress={() => toast('Sharing coming soon')} />
+      <Button title="Back to Profile" onPress={() => navigation.navigate('Profile')} />
+    </View>
+  );
+}

--- a/roamio-mobile/screens/QuestHistoryScreen.jsx
+++ b/roamio-mobile/screens/QuestHistoryScreen.jsx
@@ -1,0 +1,55 @@
+import React, { useContext, useEffect, useState } from 'react';
+import { View, Text, FlatList, Image } from 'react-native';
+import SharedHeader from '../components/SharedHeader';
+import { AppContext } from '../context/AppContext';
+import { collection, getDocs, query, orderBy } from 'firebase/firestore';
+import { db } from '../firebase';
+
+export default function QuestHistoryScreen() {
+  const { user } = useContext(AppContext);
+  const [quests, setQuests] = useState([]);
+
+  useEffect(() => {
+    if (!user) return;
+    (async () => {
+      try {
+        const q = query(
+          collection(db, 'user_quests', user.uid, 'quests'),
+          orderBy('completedAt', 'desc')
+        );
+        const snap = await getDocs(q);
+        const arr = [];
+        snap.forEach((doc) => arr.push({ id: doc.id, ...doc.data() }));
+        setQuests(arr);
+      } catch (err) {
+        console.log('history load', err);
+      }
+    })();
+  }, [user]);
+
+  return (
+    <View className="flex-1 p-4">
+      <SharedHeader title="Quest History" />
+      <FlatList
+        data={quests}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View className="flex-row items-center mb-2">
+            {item.postcardUrl && (
+              <Image source={{ uri: item.postcardUrl }} className="w-16 h-16 mr-2" />
+            )}
+            <View>
+              <Text className="font-bold">{item.title}</Text>
+              <Text className="text-xs text-gray-600">
+                {item.completedAt
+                  ? new Date(item.completedAt).toLocaleDateString()
+                  : ''}
+              </Text>
+            </View>
+          </View>
+        )}
+        ListEmptyComponent={<Text>No quests completed yet</Text>}
+      />
+    </View>
+  );
+}

--- a/roamio-mobile/screens/QuestLiveScreen.jsx
+++ b/roamio-mobile/screens/QuestLiveScreen.jsx
@@ -77,9 +77,16 @@ export default function QuestLiveScreen({ navigation }) {
   };
 
   const handleComplete = async () => {
-    await completeQuest({ ...quest, visitedIndices: quest.visitedIndices || [] });
+    const summary = await completeQuest({
+      ...quest,
+      visitedIndices: quest.visitedIndices || [],
+    });
     setQuest(null);
-    navigation.navigate('Profile');
+    if (summary) {
+      navigation.navigate('QuestComplete', { summary });
+    } else {
+      navigation.navigate('Profile');
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- add quest completion summary screen
- display XP, level, streak and badges in Profile
- include onboarding flow, leaderboard, and quest history
- show quest complete navigation
- expose new screens in navigator and context states

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6883bbf7182c8321a0bdb055363c7a3f