### PR TITLE
Fix premium validation and demo quest fallback

### DIFF
--- a/backend/auth_utils.py
+++ b/backend/auth_utils.py
@@ -2,8 +2,10 @@ import os
 import asyncio
 import re
 from fastapi import Depends, HTTPException, Request
-from google.oauth2 import service_account, id_token
-from google.auth.transport.requests import AuthorizedSession, Request as GoogleRequest
+from google.oauth2 import service_account
+from google.auth.transport.requests import AuthorizedSession
+import firebase_admin
+from firebase_admin import auth as fb_auth
 from dotenv import load_dotenv
 load_dotenv()
 
@@ -14,6 +16,10 @@ creds = service_account.Credentials.from_service_account_file(
 )
 rest_session = AuthorizedSession(creds)
 PROJECT_ID = creds.project_id
+
+# Initialize Firebase Admin if not already
+if not firebase_admin._apps:
+    firebase_admin.initialize_app()
 
 
 def _from_value(val):
@@ -57,17 +63,10 @@ async def verify_token(auth_header: str | None) -> str | None:
         return None
     token = auth_header.split(" ", 1)[1]
     try:
-        client_id = os.getenv("FIREBASE_CLIENT_ID")
-        info = id_token.verify_oauth2_token(
-            token,
-            GoogleRequest(),
-            audience=client_id,
-        )
-        issuer = info.get("iss")
-        if issuer != f"https://securetoken.google.com/{PROJECT_ID}":
-            raise ValueError("Wrong issuer")
-        return info.get("uid") or info.get("sub")
-    except Exception:
+        decoded = await asyncio.to_thread(fb_auth.verify_id_token, token)
+        return decoded.get("uid")
+    except Exception as e:
+        print("verify_token error", e)
         return None
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI, Query, Body, Request, Depends
+from fastapi import FastAPI, Query, Body, Request, Depends, Header, HTTPException
 from fastapi.responses import JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 import os
@@ -451,15 +451,43 @@ async def generate_quest(
     city: str = Body(...),
     moods: list[str] = Body(...),
     time_limit: int = Body(...),
-    token: str = Body(...),
+    authorization: str = Header(...),
     user_id: str | None = Body(None),
     difficulty: str = Body("Easy"),
     lat: float | None = Body(None),
     lng: float | None = Body(None),
+    is_demo: bool = Body(False),
 ):
     """Generate a quest using tag-based filtering and optional GPT text."""
+    uid = await verify_token(authorization)
+    if not uid:
+        print("[generate_quest] invalid or missing token")
+        raise HTTPException(status_code=401, detail="Invalid or missing token")
+    print(f"[generate_quest] UID={uid}, city={city}, moods={moods}, demo={is_demo}")
+    if not user_id:
+        user_id = uid
     if not city or not moods:
         return {"error": "City and mood list are required."}
+
+    if is_demo:
+        return {
+            "quest": {
+                "questText": "Welcome adventurer! Try this fun intro route.",
+                "places": [
+                    {"name": "Welcome Plaza", "lat": 37.7749, "lng": -122.4194, "type": "tourist_attraction"},
+                    {"name": "Local Cafe", "lat": 37.7750, "lng": -122.4180, "type": "cafe"},
+                    {"name": "Riverside Walk", "lat": 37.7755, "lng": -122.4170, "type": "park"},
+                ],
+                "difficulty": "Easy",
+                "route": {"legs": [], "polyline": "", "total_distance": "0.5 miles", "total_duration": "15 minutes"},
+                "timestamp": datetime.utcnow().isoformat(),
+                "generationMethod": "demo",
+                "tagSource": "manual",
+                "tags": ["demo", "intro"],
+                "city": "Demo City",
+                "mood": "adventure",
+            }
+        }
 
     preferred = get_user_preferred_tags(user_id) if user_id else []
 
@@ -592,7 +620,25 @@ async def generate_quest(
             break
 
     if len(selected) < 3:
-        return {"error": "Not enough matching places"}
+        print("[generate_quest] Not enough matching places, using demo quest")
+        return {
+            "quest": {
+                "questText": "Welcome adventurer! Try this fun intro route.",
+                "places": [
+                    {"name": "Welcome Plaza", "lat": 37.7749, "lng": -122.4194, "type": "tourist_attraction"},
+                    {"name": "Local Cafe", "lat": 37.7750, "lng": -122.4180, "type": "cafe"},
+                    {"name": "Riverside Walk", "lat": 37.7755, "lng": -122.4170, "type": "park"},
+                ],
+                "difficulty": "Easy",
+                "route": {"legs": [], "polyline": "", "total_distance": "0.5 miles", "total_duration": "15 minutes"},
+                "timestamp": datetime.utcnow().isoformat(),
+                "generationMethod": "demo",
+                "tagSource": "manual",
+                "tags": ["demo", "intro"],
+                "city": "Demo City",
+                "mood": "adventure",
+            }
+        }
 
     loc_hash = f"{city_location['lat']:.2f}_{city_location['lng']:.2f}"
     tag_combo = "-".join(sorted(preferred)) if preferred else "none"
@@ -1306,16 +1352,18 @@ async def upload_postcard(
 
 
 @app.post("/reroll-quest")
-async def reroll_quest(payload: dict = Body(...)):
+async def reroll_quest(payload: dict = Body(...), authorization: str = Header(...)):
     """Regenerate a quest for the same parameters."""
     city = payload.get("city")
     moods = payload.get("moods", [])
     time_limit = payload.get("time_limit", 60)
-    token = payload.get("token", "")
     # Reuse generate_quest logic
     lat = payload.get("lat")
     lng = payload.get("lng")
-    return await generate_quest(city=city, moods=moods, time_limit=time_limit, token=token, lat=lat, lng=lng)
+    is_demo = payload.get("is_demo", False)
+    return await generate_quest(city=city, moods=moods, time_limit=time_limit,
+                               authorization=authorization, user_id=None,
+                               lat=lat, lng=lng, is_demo=is_demo)
 
 
 @app.post("/get-directions")
@@ -2050,15 +2098,22 @@ async def validate_premium(user_id: str, session_id: str | None = Query(None)):
 
 
 @app.post("/validate-premium")
-async def validate_premium_token(uid: str = Depends(require_user)):
+async def validate_premium_token(authorization: str = Header(...)):
     """Return premium status for the authenticated user."""
+    uid = await verify_token(authorization)
+    if not uid:
+        print("[validate-premium] missing or invalid token")
+        raise HTTPException(status_code=401, detail="Invalid or missing token")
     await check_not_banned(uid)
     project_id = creds.project_id
     url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/users/{uid}"
     resp = await asyncio.to_thread(rest_session.get, url)
     fields = _decode_document(resp.json()) if resp.status_code == 200 else {}
     premium = fields.get("isPremium") is True
-    return {"isPremium": premium}
+    if not premium:
+        print(f"[validate-premium] uid {uid} not premium")
+        raise HTTPException(status_code=403, detail="Not a premium user")
+    return {"valid": True}
 
 
 @app.post("/api/stripe-webhook")


### PR DESCRIPTION
## Summary
- improve firebase token verification using firebase_admin
- require Authorization header on `/validate-premium` and `/generate-quest`
- add demo quest fallback when not enough locations are found or when `is_demo` is passed
- update reroll quest helper to forward auth header

## Testing
- `python -m py_compile backend/auth_utils.py backend/main.py`
- `node tests/firestoreRules.test.js` *(fails: The host and port of the firestore emulator must be specified)*

------
https://chatgpt.com/codex/tasks/task_e_68852505e7c88321879ee365d05a3a6a