### PR TITLE
Fix guest auth and premium checks

### DIFF
--- a/backend/auth_utils.py
+++ b/backend/auth_utils.py
@@ -70,6 +70,20 @@ async def verify_token(auth_header: str | None) -> str | None:
         return None
 
 
+async def verify_token_info(auth_header: str | None) -> tuple[str | None, bool]:
+    """Return UID and whether the token represents an anonymous user."""
+    if not auth_header or not auth_header.startswith("Bearer "):
+        return None, False
+    token = auth_header.split(" ", 1)[1]
+    try:
+        decoded = await asyncio.to_thread(fb_auth.verify_id_token, token)
+        provider = decoded.get("firebase", {}).get("sign_in_provider")
+        return decoded.get("uid"), provider == "anonymous"
+    except Exception as e:
+        print("verify_token_info error", e)
+        return None, False
+
+
 async def _get_user_doc(uid: str) -> dict | None:
     url = (
         f"https://firestore.googleapis.com/v1/projects/{PROJECT_ID}/databases/(default)/documents/users/{uid}"

--- a/backend/main.py
+++ b/backend/main.py
@@ -22,6 +22,7 @@ from stripe_utils import create_subscription_session, verify_webhook
 from auth_utils import (
     is_premium_user,
     verify_token,
+    verify_token_info,
     require_user,
     require_admin,
     check_not_banned,
@@ -459,11 +460,11 @@ async def generate_quest(
     is_demo: bool = Body(False),
 ):
     """Generate a quest using tag-based filtering and optional GPT text."""
-    uid = await verify_token(authorization)
+    uid, is_guest = await verify_token_info(authorization)
     if not uid:
         print("[generate_quest] invalid or missing token")
         raise HTTPException(status_code=401, detail="Invalid or missing token")
-    print(f"[generate_quest] UID={uid}, city={city}, moods={moods}, demo={is_demo}")
+    print(f"[generate_quest] UID={uid}, city={city}, moods={moods}, demo={is_demo}, guest={is_guest}")
     if not user_id:
         user_id = uid
     if not city or not moods:
@@ -513,7 +514,9 @@ async def generate_quest(
                 else:
                     user_age = int(user_doc.get("age", 0))
                 prefers_clean = bool(user_doc.get("prefersCleanMode", False))
-            if usage_count >= 3:
+            if is_guest and usage_count >= 1:
+                return JSONResponse(status_code=403, content={"error": "Daily guest limit reached"})
+            if not is_guest and usage_count >= 3:
                 return JSONResponse(status_code=403, content={"error": "Daily quest limit reached"})
             # difficulty gating
             req_diff = difficulty.title()
@@ -688,12 +691,14 @@ async def generate_quest(
         )
     else:
         ordered = [selected[0]] + [selected[i+1] for i in waypoint_order] + [selected[-1]]
-    place_names = ", ".join([sanitize_input(p["name"]) for p in ordered if p.get("type") != "start"])
+    place_names = ", ".join(
+        [sanitize_input(p["name"]) for p in ordered if p.get("type") != "start"][:5]
+    )
 
     if openai.api_key:
         prompt = (
-            f"Write a short playful quest including these places: {place_names}. "
-            f"Keep it under 300 tokens. Style: {', '.join(sanitize_input(m) for m in moods)}"
+            f"Write a short playful quest including: {place_names}. "
+            f"Keep it under 250 tokens and use simple language. Style: {', '.join(sanitize_input(m) for m in moods)}"
         )
         try:
             completion = openai.ChatCompletion.create(
@@ -1060,23 +1065,21 @@ async def complete_quest(payload: dict = Body(...)):
         patch_body = {"fields": _encode_fields({"postcardUrl": postcard_url})}
         await asyncio.to_thread(rest_session.patch, quest_url, json=patch_body)
 
-    if payload.get("public"):
+    if payload.get("public") and postcard_url:
         feed_id = f"{quest_id}_{user_id}"
         feed_doc = {
-            "uid": user_id,
+            "userId": user_id,
             "imageUrl": postcard_url,
             "city": payload.get("city"),
             "timestamp": timestamp,
-            "badgesUnlocked": new_badges,
-            "xpEarned": xp_earned,
             "displayName": payload.get("displayName"),
             "mood": payload.get("mood"),
-            "questTitle": payload.get("title"),
-            "sharedFromQuestId": quest_id,
-            "isFlagged": False,
+            "title": payload.get("title"),
+            "questText": payload.get("questText"),
+            "visible": True,
         }
         feed_url = (
-            f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/ugc_feed/{feed_id}"
+            f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/community_quests/{feed_id}"
         )
         feed_body = {"fields": _encode_fields(feed_doc)}
         fr = await asyncio.to_thread(rest_session.patch, feed_url, json=feed_body)
@@ -1998,7 +2001,7 @@ async def get_community_quests():
         if not doc:
             continue
         obj = _decode_document(doc)
-        if obj.get("visible") is False:
+        if obj.get("visible") is False or not obj.get("imageUrl"):
             continue
         obj["id"] = doc["name"].split("/")[-1]
         results.append(obj)
@@ -2094,7 +2097,7 @@ async def validate_premium(user_id: str, session_id: str | None = Query(None)):
             body = {"fields": _encode_fields(fields)}
             await asyncio.to_thread(rest_session.patch, user_url, json=body)
 
-    return {"isPremium": premium}
+    return {"premium": premium}
 
 
 @app.post("/validate-premium")
@@ -2110,10 +2113,7 @@ async def validate_premium_token(authorization: str = Header(...)):
     resp = await asyncio.to_thread(rest_session.get, url)
     fields = _decode_document(resp.json()) if resp.status_code == 200 else {}
     premium = fields.get("isPremium") is True
-    if not premium:
-        print(f"[validate-premium] uid {uid} not premium")
-        raise HTTPException(status_code=403, detail="Not a premium user")
-    return {"valid": True}
+    return {"premium": premium}
 
 
 @app.post("/api/stripe-webhook")
@@ -2188,12 +2188,19 @@ async def update_active_quest(
 @app.post("/create-custom-quest")
 async def create_custom_quest(
     payload: dict = Body(...),
-    uid: str = Depends(require_user),
+    authorization: str = Header(...),
 ):
-    """Create a custom quest for the authenticated premium user."""
+    """Create a custom quest for the authenticated user or guest."""
+    uid, is_guest = await verify_token_info(authorization)
+    if not uid:
+        raise HTTPException(status_code=401, detail="Invalid or missing token")
     await check_not_banned(uid)
-    if not await is_premium_user(uid):
+    if not await is_premium_user(uid) and not is_guest:
         return JSONResponse(status_code=403, content={"error": "Premium required"})
+
+    usage_count = await get_daily_usage(uid)
+    if is_guest and usage_count >= 1:
+        return JSONResponse(status_code=403, content={"error": "Daily guest limit reached"})
 
     location_list = payload.get("locationList", [])
     if len(location_list) < 2:
@@ -2211,6 +2218,8 @@ async def create_custom_quest(
 
     try:
         quest_id = await write_custom_quest(data, uid)
+        if is_guest:
+            await increment_daily_usage(uid)
         return {"questId": quest_id}
     except Exception as e:
         print("create_custom_quest error", e)

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,7 +1,7 @@
 // src/App.jsx
 import { Routes, Route, useNavigate, useLocation } from "react-router-dom";
 import { useEffect } from "react";
-import { onAuthStateChanged, getAuth } from "firebase/auth";
+import { onAuthStateChanged, getAuth, signInAnonymously } from "firebase/auth";
 import { doc, getDoc } from "firebase/firestore";
 import { db } from "./firebase";
 import { getActiveQuest, getQuest, leaveGroup } from "./lib/api";
@@ -50,7 +50,15 @@ function App() {
   useEffect(() => {
     const auth = getAuth();
     const unsub = onAuthStateChanged(auth, async (user) => {
-      if (!user) return;
+      console.debug('auth state', user ? user.uid : 'none');
+      if (!user) {
+        try {
+          await signInAnonymously(auth);
+        } catch (err) {
+          console.error('guest sign-in failed', err);
+        }
+        return;
+      }
       try {
         const snap = await getDoc(doc(db, 'users', user.uid));
         const onboarded = snap.exists() && snap.data().onboarding;

--- a/frontend/src/components/QuestHistory.jsx
+++ b/frontend/src/components/QuestHistory.jsx
@@ -38,6 +38,7 @@ const QuestHistory = () => {
     for (let i = 0; i < delays.length; i++) {
       try {
         const data = await getUserQuests(uid);
+        console.debug('history loaded', data.quests?.length || 0);
         setQuests(data.quests || []);
         if (highlightNew && data.quests && data.quests.length > 0) {
           setHighlight(data.quests[0].id || null);
@@ -107,44 +108,54 @@ const QuestHistory = () => {
         <p className="text-[#4e974e] text-sm mb-6">Relive your past adventures and discover new paths.</p>
 
         <div className="space-y-6">
-          {quests.map((quest, index) => (
-            <Motion.div
-              key={quest.id || index}
-              initial={{ opacity: 0, y: 20 }}
-              animate={{ opacity: 1, y: 0 }}
-              transition={{ duration: 0.4, delay: index * 0.1 }}
-              className={`flex flex-col lg:flex-row gap-4 items-stretch rounded-xl bg-white p-4 shadow-md ${
-                highlight === (quest.id || null) ? 'ring-2 ring-yellow-400' : ''
-              }`}
-            >
-              <div className="flex-[2] flex flex-col justify-between gap-2">
-                <div>
-                  <h2 className="font-bold text-lg">{quest.questData?.title || quest.title || 'Quest'}</h2>
-                  <p className="text-sm text-[#4e974e]">
-                    Mood: {quest.questData?.difficulty || quest.difficulty || 'easy'} | Stops: {quest.questData?.places?.length || 0}
-                  </p>
+          {quests.map((quest, index) => {
+            const data = quest.questData || quest;
+            if (!data.questText) {
+              return (
+                <div key={quest.id || index} className="p-4 bg-white rounded shadow">
+                  Quest data missing
                 </div>
-                <div className="flex gap-2">
-                  <button
-                    onClick={() => handleReplay(quest)}
-                    className="flex items-center gap-2 bg-[#e7f3e7] text-[#0e1b0e] px-3 py-1 rounded-xl w-fit text-sm font-medium"
-                  >
-                    <svg className="w-4 h-4" viewBox="0 0 256 256" fill="currentColor">
-                      <path d="M224 128a96 96 0 01-94.7 96H128a95.4 95.4 0 01-65.9-26.2 8 8 0 0111-11.6A80 80 0 1071.4 71.4L44.6 96H72a8 8 0 010 16H24a8 8 0 01-8-8V56a8 8 0 0116 0v29.8L60.2 60A96 96 0 01224 128z" />
-                    </svg>
-                    Replay
-                  </button>
-                  <button
-                    onClick={() => handleRemix(quest)}
-                    className="flex items-center gap-2 bg-[#e7f3e7] text-[#0e1b0e] px-3 py-1 rounded-xl w-fit text-sm font-medium"
-                  >
-                    Remix
-                  </button>
+              );
+            }
+            return (
+              <Motion.div
+                key={quest.id || index}
+                initial={{ opacity: 0, y: 20 }}
+                animate={{ opacity: 1, y: 0 }}
+                transition={{ duration: 0.4, delay: index * 0.1 }}
+                className={`flex flex-col lg:flex-row gap-4 items-stretch rounded-xl bg-white p-4 shadow-md ${
+                  highlight === (quest.id || null) ? 'ring-2 ring-yellow-400' : ''
+                }`}
+              >
+                <div className="flex-[2] flex flex-col justify-between gap-2">
+                  <div>
+                    <h2 className="font-bold text-lg">{data.title || 'Quest'}</h2>
+                    <p className="text-sm text-[#4e974e]">
+                      Mood: {data.difficulty || 'easy'} | Stops: {data.places?.length || data.locationList?.length || 0}
+                    </p>
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => handleReplay(quest)}
+                      className="flex items-center gap-2 bg-[#e7f3e7] text-[#0e1b0e] px-3 py-1 rounded-xl w-fit text-sm font-medium"
+                    >
+                      <svg className="w-4 h-4" viewBox="0 0 256 256" fill="currentColor">
+                        <path d="M224 128a96 96 0 01-94.7 96H128a95.4 95.4 0 01-65.9-26.2 8 8 0 0111-11.6A80 80 0 1071.4 71.4L44.6 96H72a8 8 0 010 16H24a8 8 0 01-8-8V56a8 8 0 0116 0v29.8L60.2 60A96 96 0 01224 128z" />
+                      </svg>
+                      Replay
+                    </button>
+                    <button
+                      onClick={() => handleRemix(quest)}
+                      className="flex items-center gap-2 bg-[#e7f3e7] text-[#0e1b0e] px-3 py-1 rounded-xl w-fit text-sm font-medium"
+                    >
+                      Remix
+                    </button>
+                  </div>
                 </div>
-              </div>
-              <div className="flex-1 bg-cover bg-center aspect-video rounded-xl" style={{ backgroundImage: `url(${quest.postcardUrl || quest.imageUrl || 'https://placehold.co/600x300'})` }} />
-            </Motion.div>
-          ))}
+                <div className="flex-1 bg-cover bg-center aspect-video rounded-xl" style={{ backgroundImage: `url(${quest.postcardUrl || quest.imageUrl || 'https://placehold.co/600x300'})` }} />
+              </Motion.div>
+            );
+          })}
         </div>
       </section>
     </div>

--- a/frontend/src/lib/api.js
+++ b/frontend/src/lib/api.js
@@ -86,18 +86,20 @@ export async function validatePremium(userId, sessionId) {
     url.searchParams.set('session_id', sessionId);
     const resp = await fetch(url.toString());
     if (!resp.ok) throw new Error('Failed to validate premium');
-    return resp.json();
+    const data = await resp.json();
+    return { premium: !!data.premium, isPremium: !!data.premium };
   }
   const auth = getAuth();
   const user = auth.currentUser;
-  if (!user) return { isPremium: false };
+  if (!user) return { premium: false, isPremium: false };
   const token = await user.getIdToken();
   const resp = await fetch(`${BASE_URL}/validate-premium`, {
     method: 'POST',
     headers: { Authorization: `Bearer ${token}` },
   });
   if (!resp.ok) throw new Error('Failed to validate premium');
-  return resp.json();
+  const data = await resp.json();
+  return { premium: !!data.premium, isPremium: !!data.premium };
 }
 
 export async function getUserQuests(userId) {


### PR DESCRIPTION
## Summary
- allow guest token verification and adjust daily limits
- return boolean from premium validation endpoints
- update quest prompt and community feed logic
- improve quest history rendering and logging
- automatically sign in guests and report auth state

## Testing
- `npm run lint`
- `python -m py_compile main.py auth_utils.py firestore_utils.py stripe_utils.py group_utils.py emotion_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68852a885f288321b865ee4b2e7e8c2d