### PR TITLE
Fix quest flow and backend write paths

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -64,6 +64,11 @@ This app showcases full-stack AI integration with Google Cloud infrastructure, g
 }
 ```
 
+## API Endpoints
+
+- `POST /generate-quest` – create a new quest
+- `POST /get-directions` – proxy Google Maps Directions API and return the raw response
+
 ## 💻 Dev Setup
 
 ```bash

--- a/backend/main.py
+++ b/backend/main.py
@@ -1371,34 +1371,26 @@ async def reroll_quest(payload: dict = Body(...), authorization: str = Header(..
 
 @app.post("/get-directions")
 async def get_directions(payload: dict = Body(...)):
-    print("Received /get-directions payload:", payload)
-    try:
-        places = payload.get("places", [])
-        if not places or len(places) < 2:
-            return {"error": "At least two valid places required"}
-
+    """Proxy Google Maps directions to avoid CORS issues."""
+    origin = payload.get("origin")
+    destination = payload.get("destination")
+    waypoints = payload.get("waypoints", [])
+    places = payload.get("places")
+    if places and len(places) >= 2:
         origin = f"{places[0]['lat']},{places[0]['lng']}"
         destination = f"{places[-1]['lat']},{places[-1]['lng']}"
         waypoints = [f"{p['lat']},{p['lng']}" for p in places[1:-1]]
-
-        directions_result = gmaps.directions(
-            origin=origin,
-            destination=destination,
+    try:
+        directions = gmaps.directions(
+            origin,
+            destination,
             waypoints=waypoints,
             mode="walking",
             optimize_waypoints=True,
         )
-
-        if not directions_result:
-            return {"error": "No route found"}
-
-        route = directions_result[0]
-        return {
-            "polyline": route.get("overview_polyline", {}).get("points", ""),
-            "legs": route.get("legs", []),
-        }
+        return {"directions": directions}
     except Exception as e:
-        print("Error fetching directions:", str(e))
+        print("Error fetching directions:", e)
         return {"error": str(e)}
 
 
@@ -2387,8 +2379,9 @@ async def like_quest(
     # TODO: enforce one like per user in Firestore security rules  # 🔒 MANUAL FIX NEEDED
 
     project_id = creds.project_id
+    doc_id = f"{quest_id}_{user_id}"
     like_url = (
-        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/quest_likes/{quest_id}/{user_id}"
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/quest_likes/{doc_id}"
     )
     body = {"fields": _encode_fields({"timestamp": datetime.utcnow().isoformat()})}
     resp = await asyncio.to_thread(rest_session.patch, like_url, json=body)
@@ -2422,8 +2415,9 @@ async def view_quest(
     await check_not_banned(uid)
 
     project_id = creds.project_id
+    doc_id = f"{quest_id}_{user_id}"
     view_doc = (
-        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/quest_views/{quest_id}/{user_id}"
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/quest_views/{doc_id}"
     )
     resp = await asyncio.to_thread(rest_session.get, view_doc)
     if resp.status_code == 404:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -9,7 +9,7 @@ import LandingPage from "./components/LandingPage";
 import WelcomePage from "./pages/WelcomePage";
 import OnboardingFlow from "./pages/OnboardingFlow";
 import QuestHome from "./components/QuestHome";
-import QuestDetails from "./components/QuestDetails";
+import QuestDetails from "./pages/QuestDetailsPage";
 import QuestHistory from "./components/QuestHistory";
 import Profile from "./components/Profile";
 import PostcardGalleryPage from "./pages/PostcardGalleryPage";
@@ -95,7 +95,7 @@ function App() {
         <Route path="/landing" element={<LandingPage />} />
         <Route path="/home" element={<QuestHome />} />
         <Route path="/onboarding" element={<OnboardingFlow />} />
-        <Route path="/details" element={<QuestDetails />} />
+        <Route path="/quest-details" element={<QuestDetails />} />
         <Route path="/quest/:city/:mood/route" element={<QuestRoute />} />
         <Route path="/history" element={<QuestHistory />} />
         <Route path="/profile" element={<Profile />} />

--- a/frontend/src/components/CustomQuestBuilder.jsx
+++ b/frontend/src/components/CustomQuestBuilder.jsx
@@ -156,7 +156,7 @@ export default function CustomQuestBuilder() {
       }
       const quest = await getCustomQuest(id);
       const group = await createGroupQuest(user.uid, id, user.displayName);
-      navigate('/live', { state: { quest, questId: id, groupId: group.groupId, timeLimit } });
+      navigate('/quest-details', { state: { quest, questId: id, groupId: group.groupId, timeLimit } });
     } catch (err) {
       console.error('❌ API error:', err);
       setError('Something went wrong starting custom quest.');

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { signInWithPopup } from "firebase/auth";
+import { signInWithPopup, signInAnonymously } from "firebase/auth";
 import { auth, provider } from "../firebase";
 
 const Login = () => {
@@ -12,6 +12,15 @@ const Login = () => {
     }
   };
 
+  const handleGuest = async () => {
+    try {
+      await signInAnonymously(auth);
+      console.log('Guest login success');
+    } catch (error) {
+      console.error('Guest login failed', error);
+    }
+  };
+
   return (
     <div className="space-y-2 text-center">
       <button
@@ -19,6 +28,12 @@ const Login = () => {
         className="bg-green-600 text-white px-4 py-2 rounded-lg"
       >
         Sign In with Google
+      </button>
+      <button
+        onClick={handleGuest}
+        className="bg-gray-200 text-gray-800 px-4 py-2 rounded-lg mt-2"
+      >
+        Continue as Guest
       </button>
       <p className="text-xs text-gray-500 mt-2">
         By signing in, you agree to our{' '}

--- a/frontend/src/components/PublicQuestPage.jsx
+++ b/frontend/src/components/PublicQuestPage.jsx
@@ -71,7 +71,7 @@ export default function PublicQuestPage() {
       const res = await createCustomQuest(payload);
       const group = await createGroupQuest(user.uid, res.questId, user.displayName);
       await replayQuest(questId, user.uid).catch(() => {});
-      navigate('/live', { state: { quest, questId: res.questId, groupId: group.groupId } });
+      navigate('/quest-details', { state: { quest, questId: res.questId, groupId: group.groupId } });
     } catch (err) {
       console.error('start failed', err);
     }

--- a/frontend/src/components/QuestHome.jsx
+++ b/frontend/src/components/QuestHome.jsx
@@ -217,7 +217,12 @@ const QuestHome = () => {
   };
 
   return (
-    <div className="min-h-screen bg-[#f8fcf8] px-6 py-8 text-[#0e1b0e] font-sans">
+    <div className="min-h-screen bg-[#f8fcf8] px-6 py-8 text-[#0e1b0e] font-sans relative">
+      {loading && (
+        <div className="absolute inset-0 flex items-center justify-center bg-black/40 text-white z-50">
+          Generating...
+        </div>
+      )}
       <h1 className="text-[32px] font-bold mb-6 text-center">Create a New Quest</h1>
       {resumeData && (
         <div className="mb-6 text-center">

--- a/frontend/src/components/QuestLivePage.jsx
+++ b/frontend/src/components/QuestLivePage.jsx
@@ -99,7 +99,6 @@ export default function QuestLivePage() {
     if (!quest || !userLocation || !quest.places?.length) return;
     const fetchOptimized = async () => {
       const VISIT_SEC = 10 * 60; // assumed time spent at each stop
-      const key = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
       const coords = quest.places.map((p) => `${p.lat},${p.lng}`);
       if (coords.length < 2) return;
 
@@ -115,14 +114,15 @@ export default function QuestLivePage() {
           }),
         });        
         const data = await res.json();
-        const order = data?.routes?.[0]?.waypoint_order;
+        const route = data?.directions?.[0];
+        const order = route?.waypoint_order;
         let ordered = quest.places;
         if (Array.isArray(order) && order.length === coords.length - 1) {
           ordered = order.map((i) => quest.places[i]);
           ordered.push(quest.places[quest.places.length - 1]);
         }
 
-        const legs = data?.legs || [];
+        const legs = route?.legs || [];
         if (legs.length > 0) {
           const sec = legs.reduce((sum, leg) => sum + (leg.duration?.value || 0), 0);
           const mins = Math.round(sec / 60);
@@ -160,7 +160,7 @@ export default function QuestLivePage() {
           console.error('failed to store optimized order', err);
         }
 
-        const poly = data?.routes?.[0]?.overview_polyline?.points;
+        const poly = route?.overview_polyline?.points;
         if (poly) {
           const decoded = decode(poly).map(([lat, lng]) => ({ lat, lng }));
           setPolylinePoints(decoded);
@@ -273,31 +273,21 @@ export default function QuestLivePage() {
 
     const fetchRoute = async () => {
       setEtaError("");
-      const origin = `${userLocation.lat},${userLocation.lng}`;
-      const key = import.meta.env.VITE_GOOGLE_MAPS_API_KEY;
-      const destination = `${remaining[remaining.length - 1].lat},${remaining[remaining.length - 1].lng}`;
-      const waypoints = remaining
-        .slice(0, -1)
-        .map((p) => `${p.lat},${p.lng}`)
-        .join('|');
-
-      console.log('Waypoints', waypoints);
-      console.log('Remaining stops', remaining);
-
-      const url = `https://maps.googleapis.com/maps/api/directions/json?origin=${origin}&destination=${destination}&mode=walking` +
-        (waypoints ? `&waypoints=${waypoints}` : '') +
-        `&key=${key}`;
-
       try {
-        const res = await fetch(url);
+        const res = await fetch(`${import.meta.env.VITE_API_URL}/get-directions`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ places: remaining })
+        });
         const data = await res.json();
-        const legs = data?.routes?.[0]?.legs || [];
+        const route = data?.directions?.[0];
+        const legs = route?.legs || [];
         if (legs.length === 0) throw new Error('No route');
         const sec = legs.reduce((s, l) => s + (l.duration?.value || 0), 0);
         const mins = Math.round(sec / 60);
         setEtaText(`${mins} min`);
         console.log('ETA legs', legs.map((l) => l.duration?.text));
-        const poly = data?.routes?.[0]?.overview_polyline?.points;
+        const poly = route?.overview_polyline?.points;
         if (poly) {
           const decoded = decode(poly).map(([lat, lng]) => ({ lat, lng }));
           setPolylinePoints(decoded);

--- a/frontend/src/pages/OnboardingFlow.jsx
+++ b/frontend/src/pages/OnboardingFlow.jsx
@@ -72,7 +72,7 @@ export default function OnboardingFlow() {
         },
         { merge: true }
       );
-      navigate('/live', { state: { quest: result.quest, questId: result.questId, timeLimit: Number(time) } });
+      navigate('/quest-details', { state: { quest: result.quest, questId: result.questId, timeLimit: Number(time) } });
     } catch (err) {
       console.error('onboarding failed', err);
       setError('Failed to start quest');

--- a/frontend/src/pages/QuestDetailsPage.jsx
+++ b/frontend/src/pages/QuestDetailsPage.jsx
@@ -1,0 +1,45 @@
+import React, { useEffect, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import RouteMap from '../components/RouteMap';
+import { getDirections } from '../lib/api';
+
+export default function QuestDetailsPage() {
+  const { state } = useLocation();
+  const navigate = useNavigate();
+  const quest = state?.quest;
+  const questId = state?.questId;
+  const [route, setRoute] = useState(state?.route || null);
+  useEffect(() => {
+    if (!route && quest?.places?.length > 1) {
+      getDirections(quest.places)
+        .then((r) => setRoute(r.directions?.[0] || null))
+        .catch((e) => console.error('directions failed', e));
+    }
+  }, [quest, route]);
+
+  if (!quest) {
+    return <div className="p-6">No quest data.</div>;
+  }
+
+  return (
+    <div className="min-h-screen px-6 py-8 text-[#0e1b0e] font-sans">
+      <h1 className="text-2xl font-bold mb-4 text-center">{quest.title || 'Your Quest'}</h1>
+      <p className="whitespace-pre-line mb-4 text-center">{quest.questText}</p>
+      <ul className="list-disc list-inside max-w-md mx-auto text-left mb-4">
+        {quest.places?.map((p, i) => (
+          <li key={i}>{p.name}</li>
+        ))}
+      </ul>
+      <RouteMap places={quest.places} route={route} />
+      <div className="text-center mt-6">
+        <button
+          onClick={() => navigate('/live', { state: { quest, questId } })}
+          className="bg-[#019863] text-white py-2 px-6 rounded-full font-bold"
+        >
+          Start Quest
+        </button>
+      </div>
+    </div>
+  );
+}
+

--- a/seed_fake_data.py
+++ b/seed_fake_data.py
@@ -155,9 +155,11 @@ async def seed_likes_views(users, quests):
         like_users = random.sample(users, random.randint(1, 5))
         view_users = random.sample(users, random.randint(len(like_users), len(like_users)+5))
         for uid, _ in like_users:
-            await write_doc(f"quest_likes/{qid}/{uid}", {"timestamp": datetime.utcnow().isoformat()})
+            doc_id = f"{qid}_{uid}"
+            await write_doc(f"quest_likes/{doc_id}", {"timestamp": datetime.utcnow().isoformat()})
         for uid, _ in view_users:
-            await write_doc(f"quest_views/{qid}/{uid}", {"timestamp": datetime.utcnow().isoformat()})
+            doc_id = f"{qid}_{uid}"
+            await write_doc(f"quest_views/{doc_id}", {"timestamp": datetime.utcnow().isoformat()})
         quest_patch = {
             "likesCount": len(like_users),
             "viewsCount": len(view_users),


### PR DESCRIPTION
## Summary
- flatten Firestore doc IDs for `quest_likes` and `quest_views`
- add `/get-directions` proxy endpoint
- update login page with guest login
- show loading overlay during quest generation
- introduce `QuestDetailsPage` for pre-quest summary
- route quest generation flows through `/quest-details`
- fetch Google Maps directions from backend
- document API endpoint

## Testing
- `node tests/firestoreRules.test.js` *(fails: Firestore emulator host not set)*

------
https://chatgpt.com/codex/tasks/task_e_68852f7a96e48321bb81bcbc2a688bfe