### PR TITLE
Improve quest start UX and fix feed API handling

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -437,18 +437,14 @@ CITY_FALLBACK_MAP = {
 }
 
 # ✅ Replace this with your actual frontend deployed domain
-allowed_origins = [
-    "http://localhost:5173",  # Vite dev server (local)
-    "https://real-quest-frontend.web.app",  # Firebase Hosting / production
-    "https://real-world-quest-app.web.app",  # Firebase hosted frontend
-]
+allowed_origins = ["*"]
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=allowed_origins,  # <-- FIXED
+    allow_origins=allowed_origins,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization"],
 )
 
 
@@ -1212,11 +1208,13 @@ async def get_user_quests(userId: str = Query(...)):
             ],
         }
     }
-    resp = await asyncio.to_thread(rest_session.post, url, json=query)
-    if resp.status_code != 200:
-        print("Firestore REST error", resp.text)
+    try:
+        resp = await asyncio.to_thread(rest_session.post, url, json=query)
         resp.raise_for_status()
-    raw = resp.json()
+        raw = resp.json()
+    except Exception as e:
+        print("Firestore REST error", e)
+        return {"posts": []}
     results = []
     for item in raw:
         doc = item.get("document")
@@ -1997,11 +1995,13 @@ async def get_community_quests():
             "limit": 20,
         }
     }
-    resp = await asyncio.to_thread(rest_session.post, url, json=query)
-    if resp.status_code != 200:
-        print("Firestore REST error", resp.text)
+    try:
+        resp = await asyncio.to_thread(rest_session.post, url, json=query)
         resp.raise_for_status()
-    raw = resp.json()
+        raw = resp.json()
+    except Exception as e:
+        print("Firestore REST error", e)
+        return {"quests": []}
     results = []
     for item in raw:
         doc = item.get("document")
@@ -2108,12 +2108,11 @@ async def validate_premium(user_id: str, session_id: str | None = Query(None)):
 
 
 @app.post("/validate-premium")
-async def validate_premium_token(authorization: str = Header(...)):
+async def validate_premium_token(authorization: str | None = Header(None)):
     """Return premium status for the authenticated user."""
-    uid = await verify_token(authorization)
+    uid = await verify_token(authorization) if authorization else None
     if not uid:
-        print("[validate-premium] missing or invalid token")
-        raise HTTPException(status_code=401, detail="Invalid or missing token")
+        return {"premium": False}
     await check_not_banned(uid)
     project_id = creds.project_id
     url = f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/users/{uid}"

--- a/frontend/src/components/CommunityFeed.jsx
+++ b/frontend/src/components/CommunityFeed.jsx
@@ -37,7 +37,11 @@ export default function CommunityFeed() {
   };
 
   if (loading) return <div className="p-6">Loading...</div>;
-  if (error) return <div className="p-6 text-red-600">{error}</div>;
+  if (error) return (
+    <div className="p-6 text-red-600">
+      Could not load feed. <button onClick={() => window.location.reload()} className="underline">Retry?</button>
+    </div>
+  );
   if (quests.length === 0) return <div className="p-6">Join the fun – no recent community quests yet.</div>;
 
   return (

--- a/frontend/src/components/QuestHome.jsx
+++ b/frontend/src/components/QuestHome.jsx
@@ -126,6 +126,18 @@ const QuestHome = () => {
     });
   }, []);
 
+  useEffect(() => {
+    if (!coords || !window.google || !window.google.maps) return;
+    const geocoder = new window.google.maps.Geocoder();
+    geocoder.geocode({ location: coords }, (res, status) => {
+      if (status === 'OK' && res[0]) {
+        const { formatted_address, place_id } = res[0];
+        setStartLocation({ address: formatted_address, lat: coords.lat, lng: coords.lng, placeId: place_id });
+        setCity(formatted_address);
+      }
+    });
+  }, [coords]);
+
   const handleLogin = async () => {
     const auth = getAuth();
     const provider = new GoogleAuthProvider();
@@ -164,8 +176,8 @@ const QuestHome = () => {
       return;
     }
 
-    if (!startLocation || !Array.isArray(mood) || mood.length === 0 || isNaN(timeLimit)) {
-      setError("Please fill out all fields correctly.");
+    if ((!startLocation && !coords) || !Array.isArray(mood) || mood.length === 0 || isNaN(timeLimit)) {
+      setError("Please enter a valid starting location or use your current location.");
       return;
     }
 

--- a/frontend/src/components/RouteMap.jsx
+++ b/frontend/src/components/RouteMap.jsx
@@ -31,6 +31,7 @@ const Pin = ({ type, name }) => {
 };
 
 const RouteMap = ({ places = [], route = null }) => {
+  const [mapError, setMapError] = React.useState(false);
   const parseLatLng = (val) => {
     const num = parseFloat(val);
     return isNaN(num) ? null : num;
@@ -65,29 +66,44 @@ const RouteMap = ({ places = [], route = null }) => {
       polyline.setMap(map);
     } catch (err) {
       console.error("Failed to render polyline:", err);
+      setMapError(true);
     }
   };
 
   return (
     <div className="w-full my-6 space-y-4">
       <div className="h-[400px] w-full rounded-xl overflow-hidden shadow-md">
-        <GoogleMapReact
-          bootstrapURLKeys={{ key: GOOGLE_MAPS_API_KEY }}
-          defaultCenter={center}
-          defaultZoom={13}
-          yesIWantToUseGoogleMapApiInternals
-          onGoogleApiLoaded={({ map, maps }) => drawRoute(map, maps)}
-        >
-          {orderedPlaces.map((place, index) => (
-            <Pin
-              key={index}
-              lat={parseLatLng(place.lat)}
-              lng={parseLatLng(place.lng)}
-              name={place.name}
-              type={place.type}
-            />
-          ))}
-        </GoogleMapReact>
+        {mapError ? (
+          <div className="flex items-center justify-center h-full text-sm">
+            Unable to load map.{' '}
+            <a
+              href={`https://maps.google.com/?q=${center.lat},${center.lng}`}
+              className="underline ml-1"
+              target="_blank"
+            >
+              View in Google Maps?
+            </a>
+          </div>
+        ) : (
+          <GoogleMapReact
+            bootstrapURLKeys={{ key: GOOGLE_MAPS_API_KEY }}
+            defaultCenter={center}
+            defaultZoom={13}
+            yesIWantToUseGoogleMapApiInternals
+            onGoogleApiLoaded={({ map, maps }) => drawRoute(map, maps)}
+            onError={() => setMapError(true)}
+          >
+            {orderedPlaces.map((place, index) => (
+              <Pin
+                key={index}
+                lat={parseLatLng(place.lat)}
+                lng={parseLatLng(place.lng)}
+                name={place.name}
+                type={place.type}
+              />
+            ))}
+          </GoogleMapReact>
+        )}
       </div>
 
       <div className="space-y-4 px-4 mt-4 text-left">

--- a/frontend/src/pages/UGCFeed.jsx
+++ b/frontend/src/pages/UGCFeed.jsx
@@ -5,6 +5,7 @@ import { getUGCFeed } from '../lib/api';
 export default function UGCFeed() {
   const [posts, setPosts] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
   const [mood, setMood] = useState('');
   const [city, setCity] = useState('');
 
@@ -13,8 +14,10 @@ export default function UGCFeed() {
       try {
         const data = await getUGCFeed({ mood, city });
         setPosts(data.posts || []);
+        setError('');
       } catch (err) {
         console.error('Failed to load feed', err);
+        setError('failed');
       } finally {
         setLoading(false);
       }
@@ -22,6 +25,12 @@ export default function UGCFeed() {
   }, [mood, city]);
 
   if (loading) return <div className="p-6">Loading...</div>;
+  if (error)
+    return (
+      <div className="p-6 text-red-600">
+        Could not load feed. <button onClick={() => window.location.reload()} className="underline">Retry?</button>
+      </div>
+    );
   return (
     <div className="min-h-screen bg-[#f8fcf8] p-6 text-[#0e1b0e]">
       <h1 className="text-2xl font-bold mb-4">UGC Feed</h1>


### PR DESCRIPTION
## Summary
- adjust CORS middleware to allow any origin
- return `{premium:false}` from `/validate-premium` when unauthenticated
- handle Firestore errors gracefully in community feed endpoints
- auto reverse‑geocode GPS coordinates on quest form
- update quest validation message
- show retry UI when community/UGC feeds fail
- add map fallback handling

## Testing
- `node tests/firestoreRules.test.js` *(fails: The host and port of the firestore emulator must be specified)*

------
https://chatgpt.com/codex/tasks/task_e_68854f2c285c83219896d0ed48c6c1a1