### PR TITLE
Fix Firestore runQuery paths

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2676,8 +2676,9 @@ async def search_quests(query: str = Query(...), user_id: str | None = None):
         return any(tok in hay for tok in tokens)
 
     # community quests
+    # Run query against the community_quests collection
     cq_url = (
-        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/community_quests:runQuery"
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents:runQuery"
     )
     cq_query = {
         "structuredQuery": {
@@ -2698,8 +2699,9 @@ async def search_quests(query: str = Query(...), user_id: str | None = None):
                 results["public"].append(data)
 
     # custom quests (published)
+    # Published custom quests
     cust_url = (
-        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents/custom_quests:runQuery"
+        f"https://firestore.googleapis.com/v1/projects/{project_id}/databases/(default)/documents:runQuery"
     )
     cust_query = {
         "structuredQuery": {


### PR DESCRIPTION
## Summary
- correct `runQuery` endpoint usage for community and custom quest lookups
- keep CORS allowed origins for Firebase hosting domains

## Testing
- `node tests/firestoreRules.test.js` *(fails: Cannot find module '@firebase/rules-unit-testing')*

------
https://chatgpt.com/codex/tasks/task_e_6887d66d2b548321b461ff62f7b0c87d