### PR TITLE
Graceful Firestore session init failure

### DIFF
--- a/backend/firestore_utils.py
+++ b/backend/firestore_utils.py
@@ -3,15 +3,9 @@ import asyncio
 import hashlib
 from typing import List, Optional
 from datetime import datetime
-from google.oauth2 import service_account
-from google.auth.transport.requests import AuthorizedSession
+from backend.lib.google_utils import get_authorized_session
 
-creds = service_account.Credentials.from_service_account_file(
-    os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"),
-    scopes=["https://www.googleapis.com/auth/datastore"],
-)
-rest_session = AuthorizedSession(creds)
-PROJECT_ID = creds.project_id
+rest_session, PROJECT_ID = get_authorized_session()
 
 
 def _to_value(val):

--- a/backend/group_utils.py
+++ b/backend/group_utils.py
@@ -4,17 +4,10 @@ from datetime import datetime
 from typing import Tuple
 import asyncio
 
-from google.auth.transport.requests import AuthorizedSession
-from google.oauth2 import service_account
-
+from backend.lib.google_utils import get_authorized_session
 from backend.firestore_utils import _encode_fields, _decode_document
 
-creds = service_account.Credentials.from_service_account_file(
-    os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"),
-    scopes=["https://www.googleapis.com/auth/datastore"],
-)
-rest_session = AuthorizedSession(creds)
-PROJECT_ID = creds.project_id
+rest_session, PROJECT_ID = get_authorized_session()
 
 async def create_group_document(user_id: str, quest_id: str, display_name: str) -> Tuple[str, dict]:
     """Helper to create group quest and return groupId and document body."""

--- a/backend/lib/google_utils.py
+++ b/backend/lib/google_utils.py
@@ -1,0 +1,34 @@
+import os
+import traceback
+import google.auth
+from google.auth.transport.requests import AuthorizedSession
+from google.oauth2 import service_account
+
+
+def get_authorized_session(scopes=None):
+    """Return AuthorizedSession and project_id using default credentials."""
+    scopes = scopes or ["https://www.googleapis.com/auth/datastore"]
+    creds = None
+    project_id = None
+    cred_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if cred_path:
+        try:
+            creds = service_account.Credentials.from_service_account_file(
+                cred_path, scopes=scopes
+            )
+            project_id = creds.project_id
+        except Exception as e:
+            print("⚠️  Failed to load service account file:", e)
+    if not creds:
+        try:
+            creds, project_id = google.auth.default(scopes=scopes)
+        except Exception as e:
+            print("❌ Google ADC fetch failed:", e)
+            traceback.print_exc()
+            return None, None
+    try:
+        return AuthorizedSession(creds), project_id
+    except Exception as e:
+        print("❌ Failed to create AuthorizedSession:", e)
+        traceback.print_exc()
+        return None, None

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,47 +1,75 @@
 print("🔥 booted")
-print("🔥 Starting backend.main.py")
+print("🔥 Starting backend.main")
+
+from fastapi import Query, Body, Request, Depends, APIRouter, HTTPException
+from typing import Any
+import asyncio
+import requests
+import json
+from fastapi.responses import JSONResponse
+from fastapi.middleware.cors import CORSMiddleware
+import os
+import traceback
+import requests
+import hashlib
+from datetime import datetime, timedelta
+import asyncio
+import certifi
+import google.auth
+from google.cloud import firestore_v1, storage
+import firebase_admin
+from firebase_admin import auth as fb_auth
+import uvicorn
+from fastapi import FastAPI
+from backend.routes import some_router  # or routes if running locally
+import openai
+import googlemaps
+from dotenv import load_dotenv
+from backend.lib.google_utils import get_authorized_session
+
+
+def _get_authorized_session():
+    """Return AuthorizedSession or None on failure."""
+    try:
+        session, _ = get_authorized_session()
+        return session
+    except Exception as e:
+        print("❌ Failed to initialize AuthorizedSession:", e)
+        traceback.print_exc()
+        return None
+
+
+def log_startup_debug():
+    print("🔥 DEBUG: Starting FastAPI app")
+    print("🔑 GOOGLE_MAPS_API_KEY set:", bool(os.environ.get("GOOGLE_MAPS_API_KEY")))
+    print("🔑 GOOGLE_APPLICATION_CREDENTIALS set:", bool(os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")))
+    print("⚙️  PORT:", os.environ.get("PORT", "8080"))
 
 try:
-    from fastapi import Query, Body, Request, Depends, APIRouter, HTTPException
-    from typing import Any
-    import asyncio
-    import requests
-    import json
-    from fastapi.responses import JSONResponse
-    from fastapi.middleware.cors import CORSMiddleware
-    import os
-    import traceback
-    import requests
-    import hashlib
-    from datetime import datetime, timedelta
-    import asyncio
-    import certifi
-    import google.auth
-    from google.cloud import firestore_v1, storage
-    from google.oauth2 import service_account
-    import firebase_admin
-    from firebase_admin import auth as fb_auth
-    import uvicorn
-    import google.auth
-    from google.auth.transport.requests import AuthorizedSession, Request as GoogleRequest
-    from fastapi import FastAPI
-    from backend.routes import some_router  # or routes if running locally
-    import openai
-    import googlemaps
+    log_startup_debug()
+    load_dotenv()
+    os.environ["SSL_CERT_FILE"] = certifi.where()
 
-    # Confirm env vars
-    print("🔑 GOOGLE_APPLICATION_CREDENTIALS:", os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"))
-    print("🔑 GOOGLE_MAPS_API_KEY:", os.environ.get("GOOGLE_MAPS_API_KEY"))
-    print("🔑 OPENAI_API_KEY:", os.environ.get("OPENAI_API_KEY"))
-    print("🔑 PORT:", os.environ.get("PORT"))
+    rest_session = _get_authorized_session()
+    if not rest_session:
+        print("⚠️  Firestore REST session not initialized")
 
-    creds = service_account.Credentials.from_service_account_info(
-    json.loads(os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")),
-    scopes=["https://www.googleapis.com/auth/datastore"],
-)
-    rest_session = AuthorizedSession(creds)
+    gmaps_key = os.environ.get("GOOGLE_MAPS_API_KEY")
+    if gmaps_key:
+        try:
+            gmaps = googlemaps.Client(key=gmaps_key, timeout=10)
+            print("✅ Google Maps Client initialized")
+        except Exception as e:
+            print("❌ Google Maps init failed:", e)
+            gmaps = None
+    else:
+        print("❌ GOOGLE_MAPS_API_KEY not set")
+        gmaps = None
 
-    gmaps = googlemaps.Client(key=os.environ.get("GOOGLE_MAPS_API_KEY"))
+    if not firebase_admin._apps:
+        firebase_admin.initialize_app()
+    print("✅ Firebase Admin initialized")
+
     openai.api_key = os.environ.get("OPENAI_API_KEY")
 
     app = FastAPI()
@@ -54,14 +82,10 @@ try:
         time.sleep(60)
 
 except Exception as e:
-    print("💥 Startup error:")
+    print("💥 FATAL STARTUP ERROR 💥")
     traceback.print_exc()
-    import time
-    time.sleep(60)  # prevent immediate crash
     raise e
 
-
-from dotenv import load_dotenv
 from backend.emotion_utils import generate_filtered_quest_payload
 from backend.stripe_utils import create_subscription_session, verify_webhook
 from backend.auth_utils import (
@@ -3708,3 +3732,7 @@ async def refresh_leaderboards():
 @app.get("/health")
 def health_check():
     return {"status": "ok"}
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", "8080"))
+    uvicorn.run("backend.main:app", host="0.0.0.0", port=port)

--- a/seed_fake_data.py
+++ b/seed_fake_data.py
@@ -4,8 +4,7 @@ import random
 from datetime import datetime
 from uuid import uuid4
 
-from google.oauth2 import service_account
-from google.auth.transport.requests import AuthorizedSession
+from backend.lib.google_utils import get_authorized_session
 
 try:
     from faker import Faker
@@ -15,13 +14,8 @@ except Exception:
 
 from backend.firestore_utils import _encode_fields
 
-# Initialize REST session using service account
-creds = service_account.Credentials.from_service_account_file(
-    os.environ.get("GOOGLE_APPLICATION_CREDENTIALS"),
-    scopes=["https://www.googleapis.com/auth/datastore"],
-)
-rest_session = AuthorizedSession(creds)
-PROJECT_ID = creds.project_id
+# Initialize REST session using service account or default credentials
+rest_session, PROJECT_ID = get_authorized_session()
 BASE_URL = f"https://firestore.googleapis.com/v1/projects/{PROJECT_ID}/databases/(default)/documents"
 
 NAMES = [


### PR DESCRIPTION
## Summary
- catch ADC failures in `google_utils.get_authorized_session`
- add helper in `backend.main` and log when Firestore session can't be created

## Testing
- `node tests/firestoreRules.test.js` *(fails: firestore emulator must be specified)*

------
https://chatgpt.com/codex/tasks/task_e_6888f056e3b48321b8a33473c3999800