### PR TITLE
Use Secret Manager for Firestore creds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy backend source
 COPY backend ./backend
 
-# Optionally copy service account key if present
-COPY backend/firestore-key.json ./backend/firestore-key.json
-
 # Cloud Run expects the app to listen on port 8080
 ENV PORT=8080
+ENV GOOGLE_APPLICATION_CREDENTIALS=/secrets/firestore-key.json
 
 CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -37,11 +37,11 @@ def _get_authorized_session():
     import traceback
 
     try:
-        path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
-        print("🔍 Env var GOOGLE_APPLICATION_CREDENTIALS =", path)
-
-        if not path:
-            raise EnvironmentError("GOOGLE_APPLICATION_CREDENTIALS not set")
+        path = os.environ.get(
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "/secrets/firestore-key.json",
+        )
+        print("🔐 GOOGLE_APPLICATION_CREDENTIALS:", path)
 
         if not os.path.exists(path):
             raise FileNotFoundError(f"Credential file not found at: {path}")
@@ -73,7 +73,8 @@ if not rest_session:
 def log_startup_debug():
     print("🔥 DEBUG: Starting FastAPI app")
     print("🔑 GOOGLE_MAPS_API_KEY set:", bool(os.environ.get("GOOGLE_MAPS_API_KEY")))
-    print("🔑 GOOGLE_APPLICATION_CREDENTIALS set:", bool(os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")))
+    cred_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "/secrets/firestore-key.json")
+    print("🔑 GOOGLE_APPLICATION_CREDENTIALS path:", cred_path)
     print("⚙️  PORT:", os.environ.get("PORT", "8080"))
 
 try:


### PR DESCRIPTION
## Summary
- use `/secrets/firestore-key.json` as the default credentials path
- show credentials path in startup logs
- set `GOOGLE_APPLICATION_CREDENTIALS` env var in Dockerfile
- remove Dockerfile copy of the placeholder key

## Testing
- `node tests/firestoreRules.test.js` *(fails: Cannot find module '@firebase/rules-unit-testing')*
- `env NODE_PATH=$(npm root -g) firebase emulators:exec --project demo-test --only firestore "node tests/firestoreRules.test.js"` *(fails: The firestore emulator is not running)*

------
https://chatgpt.com/codex/tasks/task_e_688902b3ed9c83218fcfd9e0bc263949