### PR TITLE
Use Secret Manager for Firestore creds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,8 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy backend source
 COPY backend ./backend
 
-# Optionally copy service account key if present
-COPY backend/firestore-key.json ./backend/firestore-key.json
-
 # Cloud Run expects the app to listen on port 8080
 ENV PORT=8080
+ENV GOOGLE_APPLICATION_CREDENTIALS=/secrets/firestore-key.json
 
 CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -32,31 +32,24 @@ app = FastAPI()
 
 
 def _get_authorized_session():
+    """Create an AuthorizedSession using default application credentials."""
     from google.auth.transport.requests import AuthorizedSession
-    from google.oauth2 import service_account
     import traceback
 
     try:
-        path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
-        print("🔍 Env var GOOGLE_APPLICATION_CREDENTIALS =", path)
+        cred_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+        if cred_path:
+            print("🔐 GOOGLE_APPLICATION_CREDENTIALS:", cred_path)
+        else:
+            print("🔐 GOOGLE_APPLICATION_CREDENTIALS not set; using metadata")
 
-        if not path:
-            raise EnvironmentError("GOOGLE_APPLICATION_CREDENTIALS not set")
-
-        if not os.path.exists(path):
-            raise FileNotFoundError(f"Credential file not found at: {path}")
-
-        if not os.access(path, os.R_OK):
-            raise PermissionError(f"Credential file not readable: {path}")
-
-        creds = service_account.Credentials.from_service_account_file(
-            path,
-            scopes=["https://www.googleapis.com/auth/datastore"],
+        creds, _ = google.auth.default(
+            scopes=["https://www.googleapis.com/auth/datastore"]
         )
-        print("✅ Credentials loaded successfully.")
+        print("✅ Application default credentials loaded")
         return AuthorizedSession(creds)
 
-    except Exception as e:
+    except Exception:
         print("❌ AUTH INIT FAILED in _get_authorized_session()")
         traceback.print_exc()
         return None
@@ -73,7 +66,8 @@ if not rest_session:
 def log_startup_debug():
     print("🔥 DEBUG: Starting FastAPI app")
     print("🔑 GOOGLE_MAPS_API_KEY set:", bool(os.environ.get("GOOGLE_MAPS_API_KEY")))
-    print("🔑 GOOGLE_APPLICATION_CREDENTIALS set:", bool(os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")))
+    cred_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "/secrets/firestore-key.json")
+    print("🔑 GOOGLE_APPLICATION_CREDENTIALS path:", cred_path)
     print("⚙️  PORT:", os.environ.get("PORT", "8080"))
 
 try:
@@ -307,15 +301,18 @@ db = firestore_v1.Client(
 
 # Session for REST-based Firestore calls
 if rest_session is None:
-    try:
-        creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/datastore"])
-        rest_session = AuthorizedSession(creds)
-        print("✅ Firestore REST session created")
-    except Exception as cred_err:
-        print("❌ Failed to initialize Firestore defaults:", cred_err)
-        traceback.print_exc()
+    rest_session = _get_authorized_session()
+    if rest_session:
+        try:
+            creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/datastore"])
+            print("✅ Firestore REST session created")
+        except Exception as cred_err:
+            print("❌ Failed to initialize Firestore defaults:", cred_err)
+            traceback.print_exc()
+            creds = None
+            rest_session = None
+    else:
         creds = None
-        rest_session = None
 else:
     try:
         creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/datastore"])


### PR DESCRIPTION
## Summary
- use application default credentials when creating the Firestore session
- keep GOOGLE_APPLICATION_CREDENTIALS logging for mounted secrets
- use helper when initializing Firestore REST client

## Testing
- `node tests/firestoreRules.test.js` *(fails: Cannot find module '@firebase/rules-unit-testing')*
- `npx firebase emulators:exec --project demo-test --only firestore "node tests/firestoreRules.test.js"` *(fails: No emulators to start)*

------
https://chatgpt.com/codex/tasks/task_e_688902b3ed9c83218fcfd9e0bc263949