### PR TITLE
Fix Firestore auth for Cloud Run

### DIFF
--- a/backend/lib/google_utils.py
+++ b/backend/lib/google_utils.py
@@ -2,22 +2,27 @@ import os
 import google.auth
 from google.auth.transport.requests import AuthorizedSession
 from google.oauth2 import service_account
+from google.auth import default as google_auth_default
 
 
 def get_authorized_session(scopes=None):
     """Return AuthorizedSession and project_id using default credentials."""
     scopes = scopes or ["https://www.googleapis.com/auth/datastore"]
-    creds = None
-    project_id = None
     cred_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+
     if cred_path:
         try:
             creds = service_account.Credentials.from_service_account_file(
                 cred_path, scopes=scopes
             )
             project_id = creds.project_id
+            print("✅ Loaded service account from local file.")
         except Exception as e:
             print("⚠️  Failed to load service account file:", e)
-    if not creds:
-        creds, project_id = google.auth.default(scopes=scopes)
+            creds, project_id = google_auth_default(scopes=scopes)
+            print("✅ Loaded default application credentials from metadata.")
+    else:
+        creds, project_id = google_auth_default(scopes=scopes)
+        print("✅ Loaded default application credentials from metadata.")
+
     return AuthorizedSession(creds), project_id

--- a/backend/main.py
+++ b/backend/main.py
@@ -17,6 +17,8 @@ from datetime import datetime, timedelta
 import asyncio
 import certifi
 import google.auth
+from google.oauth2 import service_account
+from google.auth import default as google_auth_default
 from google.cloud import firestore_v1, storage
 import firebase_admin
 from firebase_admin import auth as fb_auth
@@ -39,14 +41,17 @@ def _get_authorized_session():
     try:
         cred_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
         if cred_path:
-            print("🔐 GOOGLE_APPLICATION_CREDENTIALS:", cred_path)
+            creds = service_account.Credentials.from_service_account_file(
+                cred_path,
+                scopes=["https://www.googleapis.com/auth/datastore"],
+            )
+            print("✅ Loaded service account from local file.")
         else:
             print("🔐 GOOGLE_APPLICATION_CREDENTIALS not set; using metadata")
-
-        creds, _ = google.auth.default(
-            scopes=["https://www.googleapis.com/auth/datastore"]
-        )
-        print("✅ Application default credentials loaded")
+            creds, _ = google_auth_default(
+                scopes=["https://www.googleapis.com/auth/datastore"]
+            )
+            print("✅ Loaded default application credentials from metadata.")
         return AuthorizedSession(creds)
 
     except Exception:
@@ -304,7 +309,7 @@ if rest_session is None:
     rest_session = _get_authorized_session()
     if rest_session:
         try:
-            creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/datastore"])
+            creds, _ = google_auth_default(scopes=["https://www.googleapis.com/auth/datastore"])
             print("✅ Firestore REST session created")
         except Exception as cred_err:
             print("❌ Failed to initialize Firestore defaults:", cred_err)
@@ -315,7 +320,7 @@ if rest_session is None:
         creds = None
 else:
     try:
-        creds, _ = google.auth.default(scopes=["https://www.googleapis.com/auth/datastore"])
+        creds, _ = google_auth_default(scopes=["https://www.googleapis.com/auth/datastore"])
     except Exception as cred_err:
         print("❌ Failed to load default credentials for Firestore:", cred_err)
         traceback.print_exc()


### PR DESCRIPTION
## Summary
- load credentials from service account file when `GOOGLE_APPLICATION_CREDENTIALS` is set
- otherwise use metadata-based credentials via `google.auth.default`
- update Firestore setup to use the new helper

## Testing
- `python -m compileall backend`
- `pip install -r backend/requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6889247eabe88321923f9cb99cf0d5b0