### PR TITLE
Fix Cloud Run startup host

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3880,5 +3880,4 @@ def health_check():
 
 
 if __name__ == "__main__":
-    port = int(os.environ.get("PORT", "8080"))
-    uvicorn.run("backend.main:app", host="0.0.0.0", port=port)
+    uvicorn.run(app, host="0.0.0.0", port=8080)


### PR DESCRIPTION
## Summary
- ensure FastAPI runs on `0.0.0.0:8080` in `backend/main.py`

## Testing
- `node tests/firestoreRules.test.js` *(fails: The host and port of the firestore emulator must be specified)*

------
https://chatgpt.com/codex/tasks/task_e_6889303537dc83219153a74026845485