### PR TITLE
Fix Cloud Run startup w/ Secret Manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,11 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-# Install dependencies separately to leverage Docker cache
-COPY backend/requirements.txt ./requirements.txt
+COPY backend /app
+
+ENV GOOGLE_APPLICATION_CREDENTIALS=/secrets/firestore-key
+ENV PYTHONUNBUFFERED=1
+
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy backend source
-COPY backend ./backend
-
-# Cloud Run expects the app to listen on port 8080
-ENV PORT=8080
-ENV GOOGLE_APPLICATION_CREDENTIALS=/secrets/firestore-key.json
-
-CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/backend/auth_utils.py
+++ b/backend/auth_utils.py
@@ -3,44 +3,26 @@ import json
 import asyncio
 import re
 from fastapi import Depends, HTTPException, Request
-import google.auth.transport.requests
-from google.cloud import secretmanager
-from google.oauth2 import service_account
 from google.auth.transport.requests import AuthorizedSession
+from google.oauth2 import service_account
 import firebase_admin
 from firebase_admin import auth as fb_auth
-from dotenv import load_dotenv
-
-load_dotenv()
 
 
-def _get_authorized_session():
-    try:
-        secret_name = "firestore-key"
-        project_id = os.environ.get("GOOGLE_CLOUD_PROJECT") or "real-world-quest-app"
-        client = secretmanager.SecretManagerServiceClient()
-        name = f"projects/{project_id}/secrets/{secret_name}/versions/latest"
+def get_authorized_session():
+    """Return an AuthorizedSession using credentials from disk."""
+    secret_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if not secret_path or not os.path.exists(secret_path):
+        raise FileNotFoundError(f"Credentials file not found at {secret_path}")
 
-        # Access the secret payload (JSON string)
-        response = client.access_secret_version(request={"name": name})
-        secret_json_str = response.payload.data.decode("UTF-8")
-        service_account_info = json.loads(secret_json_str)
-
-        # Get credentials from secret payload
-        credentials = service_account.Credentials.from_service_account_info(
-            service_account_info,
-            scopes=["https://www.googleapis.com/auth/datastore"],
-        )
-
-        return AuthorizedSession(credentials)
-
-    except Exception as e:
-        print("AUTH INIT FAILED in _get_authorized_session()")
-        print(f"❌ Could not initialize rest_session. Exiting.\n{e}")
-        raise e
+    creds = service_account.Credentials.from_service_account_file(
+        secret_path,
+        scopes=["https://www.googleapis.com/auth/datastore"],
+    )
+    return AuthorizedSession(creds)
 
 
-rest_session = _get_authorized_session()
+rest_session = get_authorized_session()
 PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT") or "real-world-quest-app"
 
 # Initialize Firebase Admin if not already

--- a/backend/main.py
+++ b/backend/main.py
@@ -25,14 +25,15 @@ from backend.routes import some_router  # or routes if running locally
 import openai
 import googlemaps
 from dotenv import load_dotenv
-from backend.auth_utils import _get_authorized_session
+from backend.auth_utils import get_authorized_session
 
 
 app = FastAPI()
 
 
 print("🔐 Attempting to get rest_session")
-rest_session = _get_authorized_session()
+session = get_authorized_session()
+rest_session = session
 if not rest_session:
     print("❌ Could not initialize rest_session. Exiting.")
     sys.exit(1)
@@ -280,7 +281,7 @@ db = firestore_v1.Client(
 
 # Session for REST-based Firestore calls
 if rest_session is None:
-    rest_session = _get_authorized_session()
+    rest_session = get_authorized_session()
 
 PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT") or "real-world-quest-app"
 
@@ -3875,9 +3876,11 @@ async def refresh_leaderboards():
 
 @app.get("/status")
 @app.get("/health")
+@app.get("/healthz")
 def health_check():
     return {"status": "ok"}
 
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", port=8080)
+    port = int(os.environ.get("PORT", 8080))
+    uvicorn.run("main:app", host="0.0.0.0", port=port)


### PR DESCRIPTION
## Summary
- load Firestore credentials from disk in `get_authorized_session`
- initialize FastAPI with `get_authorized_session`
- expose `/healthz` route and bind to env PORT
- update Dockerfile to run `uvicorn main:app` on 8080

## Testing
- `pytest -q`
- `python -m py_compile backend/main.py backend/auth_utils.py`

------
https://chatgpt.com/codex/tasks/task_e_688945384adc8321856897b530e848d0