### PR TITLE
Fix Cloud Run Docker path

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+# Ignore local virtual environments and caches
+**/__pycache__/
+backend/.venv/
+node_modules/
+*.pyc
+.DS_Store
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,15 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-COPY backend /app
+# Install dependencies first for better layer caching
+COPY backend/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy the backend package
+COPY backend /app/backend
 
 ENV GOOGLE_APPLICATION_CREDENTIALS=/secrets/firestore-key
 ENV PYTHONUNBUFFERED=1
+ENV PYTHONPATH=/app
 
-RUN pip install --no-cache-dir -r requirements.txt
-
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8080"]
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8080"]


### PR DESCRIPTION
## Summary
- add `.dockerignore` to remove local venv
- copy backend as a package and run uvicorn from that module

## Testing
- `python -m py_compile backend/*.py`
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_68894e6fb3888321ba430612b9a6ec27